### PR TITLE
11 update ability scores layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/
 OCSM.Test/obj
 OCSM.Test/bin
+OCSM/**/*.old

--- a/OCSM.Test/util/ExtensionsTest.cs
+++ b/OCSM.Test/util/ExtensionsTest.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace OCSM.Tests.util
+namespace Ocsm.Tests.util
 {
 	public class ExtensionsTest
 	{

--- a/OCSM.Test/util/LogicTests.cs
+++ b/OCSM.Test/util/LogicTests.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace OCSM.Tests.util
+namespace Ocsm.Tests.util
 {
 	public class LogicTests
 	{

--- a/OCSM/Open Character Sheet Manager.csproj
+++ b/OCSM/Open Character Sheet Manager.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.0.3">
+<Project Sdk="Godot.NET.Sdk/4.1.0">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>OpenCharacterSheetManager</RootNamespace>

--- a/OCSM/project.godot
+++ b/OCSM/project.godot
@@ -31,6 +31,12 @@ window/subwindows/embed_subwindows=false
 project/assembly_name="Open Character Sheet Manager"
 project/solution_directory="../"
 
+[editor]
+
+naming/default_signal_callback_name="handle{node_name}_{signal_name}"
+naming/default_signal_callback_to_self_name="handle{signal_name}"
+naming/scene_name_casing=1
+
 [gui]
 
 common/drop_mouse_on_gui_input_disabled=true

--- a/OCSM/project.godot
+++ b/OCSM/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Open Character Sheet Manager"
 run/main_scene="res://App.tscn"
-config/features=PackedStringArray("4.0", "C#")
+config/features=PackedStringArray("4.1", "C#")
 config/icon="res://icon.png"
 
 [autoload]

--- a/OCSM/project.godot
+++ b/OCSM/project.godot
@@ -24,6 +24,7 @@ SheetManager="*res://scripts/autoload/SheetManager.cs"
 [display]
 
 window/size/viewport_height=768
+window/energy_saving/keep_screen_on=false
 window/subwindows/embed_subwindows=false
 
 [dotnet]

--- a/OCSM/scenes/dnd/fifth/AbilityColumn.tscn
+++ b/OCSM/scenes/dnd/fifth/AbilityColumn.tscn
@@ -1,15 +1,15 @@
 [gd_scene load_steps=4 format=3 uid="uid://deu3qx5cs2s01"]
 
-[ext_resource type="Theme" uid="uid://djnv70tbq0knw" path="res://resources/Default.tres" id="1_gig77"]
-[ext_resource type="Script" path="res://scripts/nodes/dnd/fifth/AbilityNode.cs" id="2"]
-[ext_resource type="PackedScene" uid="uid://6xlybs5ki0j" path="res://scenes/dnd/fifth/Skill.tscn" id="3"]
+[ext_resource type="Theme" uid="uid://djnv70tbq0knw" path="res://resources/Default.tres" id="1_hf763"]
+[ext_resource type="Script" path="res://scripts/nodes/dnd/fifth/AbilityColumn.cs" id="2_y5s86"]
+[ext_resource type="PackedScene" uid="uid://6xlybs5ki0j" path="res://scenes/dnd/fifth/Skill.tscn" id="3_mfvte"]
 
 [node name="Ability" type="VBoxContainer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-theme = ExtResource("1_gig77")
-script = ExtResource("2")
+theme = ExtResource("1_hf763")
+script = ExtResource("2_y5s86")
 
 [node name="Name" type="Label" parent="."]
 unique_name_in_owner = true
@@ -21,6 +21,7 @@ vertical_alignment = 1
 [node name="Score" type="SpinBox" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
+tooltip_text = "Ability Score"
 max_value = 30.0
 value = 10.0
 rounded = true
@@ -29,15 +30,17 @@ alignment = 1
 [node name="Modifier" type="SpinBox" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
+tooltip_text = "Ability Modifier"
 min_value = -5.0
 max_value = 10.0
 rounded = true
 alignment = 1
 editable = false
 
-[node name="SavingThrow" parent="." instance=ExtResource("3")]
+[node name="SavingThrow" parent="." instance=ExtResource("3_mfvte")]
 unique_name_in_owner = true
 layout_mode = 2
+tooltip_text = "Saving Throw"
 Label = "Saving Throw"
 
 [node name="HSeparator" type="HSeparator" parent="."]

--- a/OCSM/scenes/dnd/fifth/AbilityRow.tscn
+++ b/OCSM/scenes/dnd/fifth/AbilityRow.tscn
@@ -17,11 +17,13 @@ script = ExtResource("1_oij4g")
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 20
 horizontal_alignment = 2
 vertical_alignment = 1
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
+size_flags_horizontal = 4
 size_flags_vertical = 4
 alignment = 1
 
@@ -46,14 +48,21 @@ value = 10.0
 rounded = true
 alignment = 1
 
-[node name="SavingThrow" parent="." instance=ExtResource("1_0oflb")]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_vertical = 4
-tooltip_text = "Saving Throw"
-
-[node name="Skills" type="VBoxContainer" parent="."]
-unique_name_in_owner = true
+[node name="VBoxContainer2" type="VBoxContainer" parent="."]
 layout_mode = 2
 size_flags_horizontal = 3
+alignment = 1
+
+[node name="SavingThrow" parent="VBoxContainer2" instance=ExtResource("1_0oflb")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 4
+tooltip_text = "Saving Throw"
+Label = "Saving Throw"
+
+[node name="Skills" type="VBoxContainer" parent="VBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 0
 alignment = 1

--- a/OCSM/scenes/dnd/fifth/AbilityRow.tscn
+++ b/OCSM/scenes/dnd/fifth/AbilityRow.tscn
@@ -1,0 +1,59 @@
+[gd_scene load_steps=3 format=3 uid="uid://8onwjd0ppers"]
+
+[ext_resource type="PackedScene" uid="uid://6xlybs5ki0j" path="res://scenes/dnd/fifth/Skill.tscn" id="1_0oflb"]
+[ext_resource type="Script" path="res://scripts/nodes/dnd/fifth/AbilityRow.cs" id="1_oij4g"]
+
+[node name="Ability" type="HBoxContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 15
+alignment = 1
+script = ExtResource("1_oij4g")
+
+[node name="Name" type="Label" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+horizontal_alignment = 2
+vertical_alignment = 1
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+size_flags_vertical = 4
+alignment = 1
+
+[node name="Modifier" type="SpinBox" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 4
+tooltip_text = "Ability Modifier"
+min_value = -5.0
+max_value = 10.0
+rounded = true
+alignment = 1
+editable = false
+
+[node name="Score" type="SpinBox" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 4
+tooltip_text = "Ability Score"
+max_value = 30.0
+value = 10.0
+rounded = true
+alignment = 1
+
+[node name="SavingThrow" parent="." instance=ExtResource("1_0oflb")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 4
+tooltip_text = "Saving Throw"
+
+[node name="Skills" type="VBoxContainer" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1

--- a/OCSM/scenes/dnd/fifth/AbilityScores.tscn
+++ b/OCSM/scenes/dnd/fifth/AbilityScores.tscn
@@ -24,7 +24,7 @@ unique_name_in_owner = true
 layout_mode = 2
 
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
-custom_minimum_size = Vector2(600, 0)
+custom_minimum_size = Vector2(500, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 
@@ -33,7 +33,7 @@ unique_name_in_owner = true
 layout_mode = 2
 
 [node name="HSeparator2" type="HSeparator" parent="VBoxContainer"]
-custom_minimum_size = Vector2(600, 0)
+custom_minimum_size = Vector2(500, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 
@@ -42,7 +42,7 @@ unique_name_in_owner = true
 layout_mode = 2
 
 [node name="HSeparator3" type="HSeparator" parent="VBoxContainer"]
-custom_minimum_size = Vector2(600, 0)
+custom_minimum_size = Vector2(500, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 
@@ -51,7 +51,7 @@ unique_name_in_owner = true
 layout_mode = 2
 
 [node name="HSeparator4" type="HSeparator" parent="VBoxContainer"]
-custom_minimum_size = Vector2(600, 0)
+custom_minimum_size = Vector2(500, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 
@@ -60,7 +60,7 @@ unique_name_in_owner = true
 layout_mode = 2
 
 [node name="HSeparator5" type="HSeparator" parent="VBoxContainer"]
-custom_minimum_size = Vector2(600, 0)
+custom_minimum_size = Vector2(500, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 

--- a/OCSM/scenes/dnd/fifth/AbilityScores.tscn
+++ b/OCSM/scenes/dnd/fifth/AbilityScores.tscn
@@ -1,0 +1,69 @@
+[gd_scene load_steps=3 format=3 uid="uid://b5ja4qd1nmj4c"]
+
+[ext_resource type="Script" path="res://scripts/nodes/dnd/fifth/AbilityScores.cs" id="1_ul5nv"]
+[ext_resource type="PackedScene" uid="uid://8onwjd0ppers" path="res://scenes/dnd/fifth/AbilityRow.tscn" id="2_p8ma2"]
+
+[node name="AbilityScores" type="MarginContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_top = 10
+script = ExtResource("1_ul5nv")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 4
+alignment = 1
+
+[node name="Strength" parent="VBoxContainer" instance=ExtResource("2_p8ma2")]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
+custom_minimum_size = Vector2(600, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="Dexterity" parent="VBoxContainer" instance=ExtResource("2_p8ma2")]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="HSeparator2" type="HSeparator" parent="VBoxContainer"]
+custom_minimum_size = Vector2(600, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="Constitution" parent="VBoxContainer" instance=ExtResource("2_p8ma2")]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="HSeparator3" type="HSeparator" parent="VBoxContainer"]
+custom_minimum_size = Vector2(600, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="Intelligence" parent="VBoxContainer" instance=ExtResource("2_p8ma2")]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="HSeparator4" type="HSeparator" parent="VBoxContainer"]
+custom_minimum_size = Vector2(600, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="Wisdom" parent="VBoxContainer" instance=ExtResource("2_p8ma2")]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="HSeparator5" type="HSeparator" parent="VBoxContainer"]
+custom_minimum_size = Vector2(600, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="Charisma" parent="VBoxContainer" instance=ExtResource("2_p8ma2")]
+unique_name_in_owner = true
+layout_mode = 2

--- a/OCSM/scenes/dnd/sheets/Fifth.tscn
+++ b/OCSM/scenes/dnd/sheets/Fifth.tscn
@@ -2,9 +2,9 @@
 
 [ext_resource type="Script" path="res://scripts/nodes/dnd/sheets/DndFifthSheet.cs" id="1"]
 [ext_resource type="Theme" uid="uid://djnv70tbq0knw" path="res://resources/Default.tres" id="1_03ki6"]
-[ext_resource type="PackedScene" uid="uid://deu3qx5cs2s01" path="res://scenes/dnd/fifth/Ability.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://dlasl05x5a5r6" path="res://scenes/nodes/ToggleButton.tscn" id="6"]
 [ext_resource type="Script" path="res://scripts/nodes/dnd/fifth/options/BackgroundOptionsButton.cs" id="7"]
+[ext_resource type="PackedScene" uid="uid://b5ja4qd1nmj4c" path="res://scenes/dnd/fifth/AbilityScores.tscn" id="7_6176l"]
 [ext_resource type="Script" path="res://scripts/nodes/dnd/fifth/options/RaceOptionsButton.cs" id="8"]
 [ext_resource type="Script" path="res://scripts/nodes/dnd/fifth/options/DieOptionsButton.cs" id="9"]
 [ext_resource type="PackedScene" uid="uid://qfhjanw2gycp" path="res://scenes/dnd/fifth/Inventory.tscn" id="11"]
@@ -15,147 +15,157 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 theme = ExtResource("1_03ki6")
 script = ExtResource("1")
 
-[node name="Column" type="VBoxContainer" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_right = 10
+
+[node name="Column" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="Label" type="Label" parent="Column"]
+[node name="Label" type="Label" parent="MarginContainer/Column"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 40
 text = "Dungeons & Dragons"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Label2" type="Label" parent="Column"]
+[node name="Label2" type="Label" parent="MarginContainer/Column"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 20
 text = "Fifth Edition"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="HSeparator" type="HSeparator" parent="Column"]
+[node name="HSeparator" type="HSeparator" parent="MarginContainer/Column"]
 layout_mode = 2
 
-[node name="Row" type="HBoxContainer" parent="Column"]
+[node name="Row" type="HBoxContainer" parent="MarginContainer/Column"]
 layout_mode = 2
 theme_override_constants/separation = 15
 alignment = 1
 
-[node name="Details" type="VBoxContainer" parent="Column/Row"]
+[node name="Details" type="VBoxContainer" parent="MarginContainer/Column/Row"]
 layout_mode = 2
 size_flags_horizontal = 3
+theme_override_constants/separation = 15
 
-[node name="Row" type="HBoxContainer" parent="Column/Row/Details"]
+[node name="Row" type="HBoxContainer" parent="MarginContainer/Column/Row/Details"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Column/Row/Details/Row"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Details/Row"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Player:"
 horizontal_alignment = 2
 vertical_alignment = 1
 
-[node name="PlayerName" type="LineEdit" parent="Column/Row/Details/Row"]
+[node name="PlayerName" type="LineEdit" parent="MarginContainer/Column/Row/Details/Row"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Row2" type="HBoxContainer" parent="Column/Row/Details"]
+[node name="Row2" type="HBoxContainer" parent="MarginContainer/Column/Row/Details"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Column/Row/Details/Row2"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Details/Row2"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Name: "
 horizontal_alignment = 2
 vertical_alignment = 1
 
-[node name="CharacterName" type="LineEdit" parent="Column/Row/Details/Row2"]
+[node name="CharacterName" type="LineEdit" parent="MarginContainer/Column/Row/Details/Row2"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Row3" type="HBoxContainer" parent="Column/Row/Details"]
+[node name="Row3" type="HBoxContainer" parent="MarginContainer/Column/Row/Details"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Column/Row/Details/Row3"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Details/Row3"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Alignment:"
 horizontal_alignment = 2
 vertical_alignment = 1
 
-[node name="Alignment" type="LineEdit" parent="Column/Row/Details/Row3"]
+[node name="Alignment" type="LineEdit" parent="MarginContainer/Column/Row/Details/Row3"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Row4" type="HBoxContainer" parent="Column/Row/Details"]
+[node name="Row4" type="HBoxContainer" parent="MarginContainer/Column/Row/Details"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Column/Row/Details/Row4"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Details/Row4"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Race:"
 horizontal_alignment = 2
 vertical_alignment = 1
 
-[node name="Race" type="OptionButton" parent="Column/Row/Details/Row4"]
+[node name="Race" type="OptionButton" parent="MarginContainer/Column/Row/Details/Row4"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 script = ExtResource("8")
 
-[node name="Row5" type="HBoxContainer" parent="Column/Row/Details"]
+[node name="Row5" type="HBoxContainer" parent="MarginContainer/Column/Row/Details"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Column/Row/Details/Row5"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Details/Row5"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Background:"
 horizontal_alignment = 2
 vertical_alignment = 1
 
-[node name="Background" type="OptionButton" parent="Column/Row/Details/Row5"]
+[node name="Background" type="OptionButton" parent="MarginContainer/Column/Row/Details/Row5"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 script = ExtResource("7")
 
-[node name="Traits" type="VBoxContainer" parent="Column/Row"]
+[node name="Traits" type="VBoxContainer" parent="MarginContainer/Column/Row"]
 layout_mode = 2
 size_flags_horizontal = 3
 alignment = 1
 
-[node name="Row1" type="HBoxContainer" parent="Column/Row/Traits"]
+[node name="Row1" type="HBoxContainer" parent="MarginContainer/Column/Row/Traits"]
 layout_mode = 2
 alignment = 1
 
-[node name="Col" type="VBoxContainer" parent="Column/Row/Traits/Row1"]
+[node name="Col" type="VBoxContainer" parent="MarginContainer/Column/Row/Traits/Row1"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Row" type="HBoxContainer" parent="Column/Row/Traits/Row1/Col"]
+[node name="Row" type="HBoxContainer" parent="MarginContainer/Column/Row/Traits/Row1/Col"]
 layout_mode = 2
 
-[node name="CurrentHP" type="SpinBox" parent="Column/Row/Traits/Row1/Col/Row"]
+[node name="CurrentHP" type="SpinBox" parent="MarginContainer/Column/Row/Traits/Row1/Col/Row"]
 unique_name_in_owner = true
 layout_mode = 2
 rounded = true
 allow_greater = true
 alignment = 1
 
-[node name="Label" type="Label" parent="Column/Row/Traits/Row1/Col/Row"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Traits/Row1/Col/Row"]
 layout_mode = 2
 text = "/"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="MaxHP" type="SpinBox" parent="Column/Row/Traits/Row1/Col/Row"]
+[node name="MaxHP" type="SpinBox" parent="MarginContainer/Column/Row/Traits/Row1/Col/Row"]
 unique_name_in_owner = true
 layout_mode = 2
 min_value = 1.0
@@ -164,62 +174,62 @@ rounded = true
 allow_greater = true
 alignment = 1
 
-[node name="Label" type="Label" parent="Column/Row/Traits/Row1/Col"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Traits/Row1/Col"]
 layout_mode = 2
 size_flags_vertical = 1
 text = "Hit Points"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Col2" type="VBoxContainer" parent="Column/Row/Traits/Row1"]
+[node name="Col2" type="VBoxContainer" parent="MarginContainer/Column/Row/Traits/Row1"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TempHP" type="SpinBox" parent="Column/Row/Traits/Row1/Col2"]
+[node name="TempHP" type="SpinBox" parent="MarginContainer/Column/Row/Traits/Row1/Col2"]
 unique_name_in_owner = true
 layout_mode = 2
 rounded = true
 allow_greater = true
 alignment = 1
 
-[node name="Label" type="Label" parent="Column/Row/Traits/Row1/Col2"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Traits/Row1/Col2"]
 layout_mode = 2
 size_flags_vertical = 1
 text = "Temp HP"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Col3" type="VBoxContainer" parent="Column/Row/Traits/Row1"]
+[node name="Col3" type="VBoxContainer" parent="MarginContainer/Column/Row/Traits/Row1"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="HitDice" type="SpinBox" parent="Column/Row/Traits/Row1/Col3"]
+[node name="HitDice" type="SpinBox" parent="MarginContainer/Column/Row/Traits/Row1/Col3"]
 unique_name_in_owner = true
 layout_mode = 2
 rounded = true
 allow_greater = true
 alignment = 1
 
-[node name="Label" type="Label" parent="Column/Row/Traits/Row1/Col3"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Traits/Row1/Col3"]
 layout_mode = 2
 size_flags_vertical = 1
 text = "Hit Dice"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="HSeparator" type="HSeparator" parent="Column/Row/Traits"]
+[node name="HSeparator" type="HSeparator" parent="MarginContainer/Column/Row/Traits"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="Row2" type="HBoxContainer" parent="Column/Row/Traits"]
+[node name="Row2" type="HBoxContainer" parent="MarginContainer/Column/Row/Traits"]
 layout_mode = 2
 alignment = 1
 
-[node name="Col" type="VBoxContainer" parent="Column/Row/Traits/Row2"]
+[node name="Col" type="VBoxContainer" parent="MarginContainer/Column/Row/Traits/Row2"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="ArmorClass" type="SpinBox" parent="Column/Row/Traits/Row2/Col"]
+[node name="ArmorClass" type="SpinBox" parent="MarginContainer/Column/Row/Traits/Row2/Col"]
 unique_name_in_owner = true
 layout_mode = 2
 rounded = true
@@ -228,18 +238,18 @@ allow_lesser = true
 alignment = 1
 editable = false
 
-[node name="Label" type="Label" parent="Column/Row/Traits/Row2/Col"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Traits/Row2/Col"]
 layout_mode = 2
 size_flags_vertical = 1
 text = "AC"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Col2" type="VBoxContainer" parent="Column/Row/Traits/Row2"]
+[node name="Col2" type="VBoxContainer" parent="MarginContainer/Column/Row/Traits/Row2"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="InitiativeBonus" type="SpinBox" parent="Column/Row/Traits/Row2/Col2"]
+[node name="InitiativeBonus" type="SpinBox" parent="MarginContainer/Column/Row/Traits/Row2/Col2"]
 unique_name_in_owner = true
 layout_mode = 2
 rounded = true
@@ -248,18 +258,18 @@ allow_lesser = true
 alignment = 1
 editable = false
 
-[node name="Label" type="Label" parent="Column/Row/Traits/Row2/Col2"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Traits/Row2/Col2"]
 layout_mode = 2
 size_flags_vertical = 1
 text = "Initiative"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Col3" type="VBoxContainer" parent="Column/Row/Traits/Row2"]
+[node name="Col3" type="VBoxContainer" parent="MarginContainer/Column/Row/Traits/Row2"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Speed" type="SpinBox" parent="Column/Row/Traits/Row2/Col3"]
+[node name="Speed" type="SpinBox" parent="MarginContainer/Column/Row/Traits/Row2/Col3"]
 unique_name_in_owner = true
 layout_mode = 2
 rounded = true
@@ -268,33 +278,33 @@ allow_lesser = true
 alignment = 1
 editable = false
 
-[node name="Label" type="Label" parent="Column/Row/Traits/Row2/Col3"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Traits/Row2/Col3"]
 layout_mode = 2
 size_flags_vertical = 1
 text = "Speed"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="HSeparator2" type="HSeparator" parent="Column/Row/Traits"]
+[node name="HSeparator2" type="HSeparator" parent="MarginContainer/Column/Row/Traits"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="Row3" type="HBoxContainer" parent="Column/Row/Traits"]
+[node name="Row3" type="HBoxContainer" parent="MarginContainer/Column/Row/Traits"]
 layout_mode = 2
 alignment = 1
 
-[node name="Col" type="VBoxContainer" parent="Column/Row/Traits/Row3"]
+[node name="Col" type="VBoxContainer" parent="MarginContainer/Column/Row/Traits/Row3"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Copper" type="SpinBox" parent="Column/Row/Traits/Row3/Col"]
+[node name="Copper" type="SpinBox" parent="MarginContainer/Column/Row/Traits/Row3/Col"]
 unique_name_in_owner = true
 layout_mode = 2
 rounded = true
 allow_greater = true
 alignment = 1
 
-[node name="Label" type="Label" parent="Column/Row/Traits/Row3/Col"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Traits/Row3/Col"]
 layout_mode = 2
 size_flags_vertical = 1
 tooltip_text = "Copper Pieces"
@@ -303,18 +313,18 @@ text = "CP"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Col2" type="VBoxContainer" parent="Column/Row/Traits/Row3"]
+[node name="Col2" type="VBoxContainer" parent="MarginContainer/Column/Row/Traits/Row3"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Silver" type="SpinBox" parent="Column/Row/Traits/Row3/Col2"]
+[node name="Silver" type="SpinBox" parent="MarginContainer/Column/Row/Traits/Row3/Col2"]
 unique_name_in_owner = true
 layout_mode = 2
 rounded = true
 allow_greater = true
 alignment = 1
 
-[node name="Label" type="Label" parent="Column/Row/Traits/Row3/Col2"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Traits/Row3/Col2"]
 layout_mode = 2
 size_flags_vertical = 1
 tooltip_text = "Silver Pieces
@@ -324,18 +334,18 @@ text = "SP"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Col3" type="VBoxContainer" parent="Column/Row/Traits/Row3"]
+[node name="Col3" type="VBoxContainer" parent="MarginContainer/Column/Row/Traits/Row3"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Electrum" type="SpinBox" parent="Column/Row/Traits/Row3/Col3"]
+[node name="Electrum" type="SpinBox" parent="MarginContainer/Column/Row/Traits/Row3/Col3"]
 unique_name_in_owner = true
 layout_mode = 2
 rounded = true
 allow_greater = true
 alignment = 1
 
-[node name="Label" type="Label" parent="Column/Row/Traits/Row3/Col3"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Traits/Row3/Col3"]
 layout_mode = 2
 size_flags_vertical = 1
 tooltip_text = "Electrum Pieces
@@ -345,17 +355,17 @@ text = "EP"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Col4" type="VBoxContainer" parent="Column/Row/Traits/Row3"]
+[node name="Col4" type="VBoxContainer" parent="MarginContainer/Column/Row/Traits/Row3"]
 layout_mode = 2
 
-[node name="Gold" type="SpinBox" parent="Column/Row/Traits/Row3/Col4"]
+[node name="Gold" type="SpinBox" parent="MarginContainer/Column/Row/Traits/Row3/Col4"]
 unique_name_in_owner = true
 layout_mode = 2
 rounded = true
 allow_greater = true
 alignment = 1
 
-[node name="Label" type="Label" parent="Column/Row/Traits/Row3/Col4"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Traits/Row3/Col4"]
 layout_mode = 2
 size_flags_vertical = 0
 tooltip_text = "Gold Pieces
@@ -365,17 +375,17 @@ text = "GP"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Col5" type="VBoxContainer" parent="Column/Row/Traits/Row3"]
+[node name="Col5" type="VBoxContainer" parent="MarginContainer/Column/Row/Traits/Row3"]
 layout_mode = 2
 
-[node name="Platinum" type="SpinBox" parent="Column/Row/Traits/Row3/Col5"]
+[node name="Platinum" type="SpinBox" parent="MarginContainer/Column/Row/Traits/Row3/Col5"]
 unique_name_in_owner = true
 layout_mode = 2
 rounded = true
 allow_greater = true
 alignment = 1
 
-[node name="Label" type="Label" parent="Column/Row/Traits/Row3/Col5"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Traits/Row3/Col5"]
 layout_mode = 2
 size_flags_vertical = 0
 tooltip_text = "Platinum Pieces
@@ -385,38 +395,38 @@ text = "PP"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="HSeparator3" type="HSeparator" parent="Column/Row/Traits"]
+[node name="HSeparator3" type="HSeparator" parent="MarginContainer/Column/Row/Traits"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="Row4" type="HBoxContainer" parent="Column/Row/Traits"]
+[node name="Row4" type="HBoxContainer" parent="MarginContainer/Column/Row/Traits"]
 layout_mode = 2
 alignment = 1
 
-[node name="Inspiration" parent="Column/Row/Traits/Row4" instance=ExtResource("6")]
+[node name="Inspiration" parent="MarginContainer/Column/Row/Traits/Row4" instance=ExtResource("6")]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 4
 
-[node name="Label" type="Label" parent="Column/Row/Traits/Row4"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Traits/Row4"]
 layout_mode = 2
 text = "Inspiration"
 vertical_alignment = 1
 
-[node name="VSeparator" type="VSeparator" parent="Column/Row/Traits/Row4"]
+[node name="VSeparator" type="VSeparator" parent="MarginContainer/Column/Row/Traits/Row4"]
 layout_mode = 2
 
-[node name="BardicInspiration" parent="Column/Row/Traits/Row4" instance=ExtResource("6")]
+[node name="BardicInspiration" parent="MarginContainer/Column/Row/Traits/Row4" instance=ExtResource("6")]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 4
 
-[node name="Label2" type="Label" parent="Column/Row/Traits/Row4"]
+[node name="Label2" type="Label" parent="MarginContainer/Column/Row/Traits/Row4"]
 layout_mode = 2
 text = "Bardic Inspiration"
 vertical_alignment = 1
 
-[node name="BardicInspirationDie" type="OptionButton" parent="Column/Row/Traits/Row4"]
+[node name="BardicInspirationDie" type="OptionButton" parent="MarginContainer/Column/Row/Traits/Row4"]
 unique_name_in_owner = true
 visible = false
 custom_minimum_size = Vector2(60, 0)
@@ -424,20 +434,20 @@ layout_mode = 2
 script = ExtResource("9")
 BardicInspiration = true
 
-[node name="Personality" type="VBoxContainer" parent="Column/Row"]
+[node name="Personality" type="VBoxContainer" parent="MarginContainer/Column/Row"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Column/Row/Personality"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/Column/Row/Personality"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Column/Row/Personality/VBoxContainer"]
+[node name="Label" type="Label" parent="MarginContainer/Column/Row/Personality/VBoxContainer"]
 layout_mode = 2
 text = "Personality Traits"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="PersonalityTraits" type="TextEdit" parent="Column/Row/Personality/VBoxContainer"]
+[node name="PersonalityTraits" type="TextEdit" parent="MarginContainer/Column/Row/Personality/VBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
@@ -446,16 +456,16 @@ size_flags_vertical = 3
 wrap_mode = 1
 scroll_fit_content_height = true
 
-[node name="VBoxContainer2" type="VBoxContainer" parent="Column/Row/Personality"]
+[node name="VBoxContainer2" type="VBoxContainer" parent="MarginContainer/Column/Row/Personality"]
 layout_mode = 2
 
-[node name="Label2" type="Label" parent="Column/Row/Personality/VBoxContainer2"]
+[node name="Label2" type="Label" parent="MarginContainer/Column/Row/Personality/VBoxContainer2"]
 layout_mode = 2
 text = "Ideals"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Ideals" type="TextEdit" parent="Column/Row/Personality/VBoxContainer2"]
+[node name="Ideals" type="TextEdit" parent="MarginContainer/Column/Row/Personality/VBoxContainer2"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
@@ -464,16 +474,16 @@ size_flags_vertical = 3
 wrap_mode = 1
 scroll_fit_content_height = true
 
-[node name="VBoxContainer3" type="VBoxContainer" parent="Column/Row/Personality"]
+[node name="VBoxContainer3" type="VBoxContainer" parent="MarginContainer/Column/Row/Personality"]
 layout_mode = 2
 
-[node name="Label3" type="Label" parent="Column/Row/Personality/VBoxContainer3"]
+[node name="Label3" type="Label" parent="MarginContainer/Column/Row/Personality/VBoxContainer3"]
 layout_mode = 2
 text = "Bonds"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Bonds" type="TextEdit" parent="Column/Row/Personality/VBoxContainer3"]
+[node name="Bonds" type="TextEdit" parent="MarginContainer/Column/Row/Personality/VBoxContainer3"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
@@ -482,16 +492,16 @@ size_flags_vertical = 3
 wrap_mode = 1
 scroll_fit_content_height = true
 
-[node name="VBoxContainer4" type="VBoxContainer" parent="Column/Row/Personality"]
+[node name="VBoxContainer4" type="VBoxContainer" parent="MarginContainer/Column/Row/Personality"]
 layout_mode = 2
 
-[node name="Label4" type="Label" parent="Column/Row/Personality/VBoxContainer4"]
+[node name="Label4" type="Label" parent="MarginContainer/Column/Row/Personality/VBoxContainer4"]
 layout_mode = 2
 text = "Flaws"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Flaws" type="TextEdit" parent="Column/Row/Personality/VBoxContainer4"]
+[node name="Flaws" type="TextEdit" parent="MarginContainer/Column/Row/Personality/VBoxContainer4"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
@@ -500,84 +510,47 @@ size_flags_vertical = 3
 wrap_mode = 1
 scroll_fit_content_height = true
 
-[node name="HSeparator2" type="HSeparator" parent="Column"]
+[node name="HSeparator2" type="HSeparator" parent="MarginContainer/Column"]
 layout_mode = 2
 
-[node name="TabBar" type="TabContainer" parent="Column"]
+[node name="TabBar" type="TabContainer" parent="MarginContainer/Column"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 tab_alignment = 1
 
-[node name="Ability Scores" type="VBoxContainer" parent="Column/TabBar"]
-layout_mode = 2
-
-[node name="Row" type="HBoxContainer" parent="Column/TabBar/Ability Scores"]
-layout_mode = 2
-alignment = 1
-
-[node name="Strength" parent="Column/TabBar/Ability Scores/Row" instance=ExtResource("4")]
+[node name="Ability Scores" parent="MarginContainer/Column/TabBar" instance=ExtResource("7_6176l")]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(180, 0)
 layout_mode = 2
 
-[node name="Dexterity" parent="Column/TabBar/Ability Scores/Row" instance=ExtResource("4")]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(180, 0)
-layout_mode = 2
-
-[node name="Constitution" parent="Column/TabBar/Ability Scores/Row" instance=ExtResource("4")]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(180, 0)
-layout_mode = 2
-
-[node name="Row2" type="HBoxContainer" parent="Column/TabBar/Ability Scores"]
-layout_mode = 2
-alignment = 1
-
-[node name="Wisdom" parent="Column/TabBar/Ability Scores/Row2" instance=ExtResource("4")]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(180, 0)
-layout_mode = 2
-
-[node name="Intelligence" parent="Column/TabBar/Ability Scores/Row2" instance=ExtResource("4")]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(180, 0)
-layout_mode = 2
-
-[node name="Charisma" parent="Column/TabBar/Ability Scores/Row2" instance=ExtResource("4")]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(180, 0)
-layout_mode = 2
-
-[node name="Actions" type="VBoxContainer" parent="Column/TabBar"]
+[node name="Actions" type="VBoxContainer" parent="MarginContainer/Column/TabBar"]
 visible = false
 layout_mode = 2
 theme_override_constants/separation = 15
 
-[node name="Classes" type="VBoxContainer" parent="Column/TabBar"]
+[node name="Classes" type="VBoxContainer" parent="MarginContainer/Column/TabBar"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 theme_override_constants/separation = 15
 
-[node name="Freatures & Traits" type="TabContainer" parent="Column/TabBar"]
+[node name="Freatures & Traits" type="TabContainer" parent="MarginContainer/Column/TabBar"]
 visible = false
 layout_mode = 2
 tab_alignment = 1
 
-[node name="Background Features" type="VBoxContainer" parent="Column/TabBar/Freatures & Traits"]
+[node name="Background Features" type="VBoxContainer" parent="MarginContainer/Column/TabBar/Freatures & Traits"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/separation = 15
 
-[node name="Racial Features" type="VBoxContainer" parent="Column/TabBar/Freatures & Traits"]
+[node name="Racial Features" type="VBoxContainer" parent="MarginContainer/Column/TabBar/Freatures & Traits"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 theme_override_constants/separation = 15
 
-[node name="Inventory" parent="Column/TabBar" instance=ExtResource("11")]
+[node name="Inventory" parent="MarginContainer/Column/TabBar" instance=ExtResource("11")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2

--- a/OCSM/scripts/api/IEmptiable.cs
+++ b/OCSM/scripts/api/IEmptiable.cs
@@ -1,5 +1,5 @@
 
-namespace OCSM.API
+namespace Ocsm.API
 {
 	/// An interface defining a means of determining if this object is empty.
 	public interface IEmptiable

--- a/OCSM/scripts/autoload/AppManager.cs
+++ b/OCSM/scripts/autoload/AppManager.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace OCSM.Nodes.Autoload
+namespace Ocsm.Nodes.Autoload
 {
 	public partial class AppManager : Node
 	{

--- a/OCSM/scripts/autoload/MetadataManager.cs
+++ b/OCSM/scripts/autoload/MetadataManager.cs
@@ -1,13 +1,13 @@
 using Godot;
 using System;
-using OCSM.Meta;
-using OCSM.CoD.Meta;
-using OCSM.CoD.CtL.Meta;
-using OCSM.DnD.Fifth.Meta;
-using OCSM.Nodes.CoD.Sheets;
-using OCSM.Nodes.DnD.Sheets;
+using Ocsm.Meta;
+using Ocsm.Cofd.Meta;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Dnd.Fifth.Meta;
+using Ocsm.Nodes.Cofd.Sheets;
+using Ocsm.Nodes.Dnd.Sheets;
 
-namespace OCSM.Nodes.Autoload
+namespace Ocsm.Nodes.Autoload
 {
 	public partial class MetadataManager : Node
 	{
@@ -34,16 +34,16 @@ namespace OCSM.Nodes.Autoload
 					
 					switch(gameSystem)
 					{
-						case Constants.GameSystem.CoD.Changeling:
-							Container = new CoDChangelingContainer();
+						case Constants.GameSystem.Cofd.Changeling:
+							Container = new CofdChangelingContainer();
 							loadGameSystemMetadata();
 							break;
-						case Constants.GameSystem.CoD.Mortal:
-							Container = new CoDCoreContainer();
+						case Constants.GameSystem.Cofd.Mortal:
+							Container = new CofdCoreContainer();
 							loadGameSystemMetadata();
 							break;
-						case Constants.GameSystem.DnD.Fifth:
-							Container = new DnDFifthContainer();
+						case Constants.GameSystem.Dnd.Fifth:
+							Container = new DndFifthContainer();
 							loadGameSystemMetadata();
 							break;
 						default:
@@ -70,11 +70,11 @@ namespace OCSM.Nodes.Autoload
 		{
 			var tab = sheetTabs.GetTabControl((int)tabIndex);
 			if(tab is ChangelingSheet)
-				CurrentGameSystem = Constants.GameSystem.CoD.Changeling;
+				CurrentGameSystem = Constants.GameSystem.Cofd.Changeling;
 			else if (tab is MortalSheet)
-				CurrentGameSystem = Constants.GameSystem.CoD.Mortal;
+				CurrentGameSystem = Constants.GameSystem.Cofd.Mortal;
 			else if (tab is DndFifthSheet)
-				CurrentGameSystem = Constants.GameSystem.DnD.Fifth;
+				CurrentGameSystem = Constants.GameSystem.Dnd.Fifth;
 			else
 				CurrentGameSystem = String.Empty;
 		}
@@ -109,10 +109,10 @@ namespace OCSM.Nodes.Autoload
 		
 		public void initializeGameSystems()
 		{
-			CurrentGameSystem = Constants.GameSystem.CoD.Changeling;
+			CurrentGameSystem = Constants.GameSystem.Cofd.Changeling;
 			if(Container.IsEmpty())
 			{
-				Container = CoDChangelingContainer.initializeWithDefaultValues();
+				Container = CofdChangelingContainer.initializeWithDefaultValues();
 				saveGameSystemMetadata();
 			}
 			

--- a/OCSM/scripts/autoload/SheetManager.cs
+++ b/OCSM/scripts/autoload/SheetManager.cs
@@ -1,8 +1,8 @@
 using Godot;
 using System;
-using OCSM.Nodes.Sheets;
+using Ocsm.Nodes.Sheets;
 
-namespace OCSM.Nodes.Autoload
+namespace Ocsm.Nodes.Autoload
 {
 	public partial class SheetManager : Node
 	{
@@ -88,22 +88,22 @@ namespace OCSM.Nodes.Autoload
 				if(sheetTabs is TabContainer)
 				{
 					var loaded = false;
-					if(json.Contains(Constants.GameSystem.CoD.Changeling))
+					if(json.Contains(Constants.GameSystem.Cofd.Changeling))
 					{
-						metadataManager.CurrentGameSystem = Constants.GameSystem.CoD.Changeling;
-						addNewSheet(Constants.Scene.CoD.Changeling.Sheet, Constants.Scene.CoD.Changeling.NewSheetName, json);
+						metadataManager.CurrentGameSystem = Constants.GameSystem.Cofd.Changeling;
+						addNewSheet(Constants.Scene.Cofd.Changeling.Sheet, Constants.Scene.Cofd.Changeling.NewSheetName, json);
 						loaded = true;
 					}
-					else if(json.Contains(Constants.GameSystem.CoD.Mortal))
+					else if(json.Contains(Constants.GameSystem.Cofd.Mortal))
 					{
-						metadataManager.CurrentGameSystem = Constants.GameSystem.CoD.Mortal;
-						addNewSheet(Constants.Scene.CoD.Mortal.Sheet, Constants.Scene.CoD.Mortal.NewSheetName, json);
+						metadataManager.CurrentGameSystem = Constants.GameSystem.Cofd.Mortal;
+						addNewSheet(Constants.Scene.Cofd.Mortal.Sheet, Constants.Scene.Cofd.Mortal.NewSheetName, json);
 						loaded = true;
 					}
-					else if(json.Contains(Constants.GameSystem.DnD.Fifth))
+					else if(json.Contains(Constants.GameSystem.Dnd.Fifth))
 					{
-						metadataManager.CurrentGameSystem = Constants.GameSystem.DnD.Fifth;
-						addNewSheet(Constants.Scene.DnD.Fifth.Sheet, Constants.Scene.DnD.Fifth.NewSheetName, json);
+						metadataManager.CurrentGameSystem = Constants.GameSystem.Dnd.Fifth;
+						addNewSheet(Constants.Scene.Dnd.Fifth.Sheet, Constants.Scene.Dnd.Fifth.NewSheetName, json);
 						loaded = true;
 					}
 					

--- a/OCSM/scripts/data/Character.cs
+++ b/OCSM/scripts/data/Character.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace OCSM
+namespace Ocsm
 {
 	public class Character
 	{

--- a/OCSM/scripts/data/Die.cs
+++ b/OCSM/scripts/data/Die.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace OCSM
+namespace Ocsm
 {
 	public class Die : IComparable<Die>, IEquatable<Die>
 	{

--- a/OCSM/scripts/data/Pair.cs
+++ b/OCSM/scripts/data/Pair.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Text.Json.Serialization;
-using OCSM.API;
+using Ocsm.API;
 
-namespace OCSM
+namespace Ocsm
 {
 	public struct Pair<K, V> : IComparable<Pair<K, V>>, IEmptiable, IEquatable<Pair<K, V>>
 		where K: IComparable<K>, IEquatable<K>

--- a/OCSM/scripts/data/cod/Advantages.cs
+++ b/OCSM/scripts/data/cod/Advantages.cs
@@ -1,5 +1,5 @@
 
-namespace OCSM.CoD
+namespace Ocsm.Cofd
 {
 	public class Advantages
 	{

--- a/OCSM/scripts/data/cod/Attribute.cs
+++ b/OCSM/scripts/data/cod/Attribute.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace OCSM.CoD
+namespace Ocsm.Cofd
 {
 	public sealed class Attribute : IComparable<Attribute>, IEquatable<Attribute>
 	{

--- a/OCSM/scripts/data/cod/Core.cs
+++ b/OCSM/scripts/data/cod/Core.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace OCSM.CoD
+namespace Ocsm.Cofd
 {
 	public class CodCore : Character
 	{

--- a/OCSM/scripts/data/cod/Details.cs
+++ b/OCSM/scripts/data/cod/Details.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace OCSM.CoD
+namespace Ocsm.Cofd
 {
 	public class Details
 	{

--- a/OCSM/scripts/data/cod/Health.cs
+++ b/OCSM/scripts/data/cod/Health.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
-using OCSM.API;
-using OCSM.Nodes;
+using Ocsm.API;
+using Ocsm.Nodes;
 
-namespace OCSM.CoD
+namespace Ocsm.Cofd
 {
 	public class Health : IComparable<Health>, IEmptiable, IEquatable<Health>
 	{

--- a/OCSM/scripts/data/cod/Merit.cs
+++ b/OCSM/scripts/data/cod/Merit.cs
@@ -1,7 +1,7 @@
 using System;
-using OCSM.Meta;
+using Ocsm.Meta;
 
-namespace OCSM.CoD
+namespace Ocsm.Cofd
 {
 	public class Merit : Metadata, IEquatable<Merit>
 	{

--- a/OCSM/scripts/data/cod/Mortal.cs
+++ b/OCSM/scripts/data/cod/Mortal.cs
@@ -1,11 +1,11 @@
 
-namespace OCSM.CoD
+namespace Ocsm.Cofd
 {
 	public class Mortal : CodCore
 	{
 		public long Age { get; set; }
 		
-		public Mortal() : base(Constants.GameSystem.CoD.Mortal)
+		public Mortal() : base(Constants.GameSystem.Cofd.Mortal)
 		{
 			Age = -1;
 		}

--- a/OCSM/scripts/data/cod/Skill.cs
+++ b/OCSM/scripts/data/cod/Skill.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace OCSM.CoD
+namespace Ocsm.Cofd
 {
 	public sealed class Skill : IComparable<Skill>, IEquatable<Skill>
 	{

--- a/OCSM/scripts/data/cod/TraitType.cs
+++ b/OCSM/scripts/data/cod/TraitType.cs
@@ -1,5 +1,5 @@
 
-namespace OCSM.CoD
+namespace Ocsm.Cofd
 {
 	public static class Trait
 	{

--- a/OCSM/scripts/data/cod/Weapon.cs
+++ b/OCSM/scripts/data/cod/Weapon.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Text.Json.Serialization;
-using OCSM.API;
+using Ocsm.API;
 
-namespace OCSM.CoD
+namespace Ocsm.Cofd
 {
 	public class Weapon : IEmptiable, IEquatable<Weapon>, IComparable<Weapon>
 	{

--- a/OCSM/scripts/data/cod/WeaponType.cs
+++ b/OCSM/scripts/data/cod/WeaponType.cs
@@ -1,5 +1,5 @@
 
-namespace OCSM.CoD
+namespace Ocsm.Cofd
 {
 	public enum WeaponType
 	{

--- a/OCSM/scripts/data/cod/ctl/Changeling.cs
+++ b/OCSM/scripts/data/cod/ctl/Changeling.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace OCSM.CoD.CtL
+namespace Ocsm.Cofd.Ctl
 {
 	public class Changeling : CodCore
 	{
@@ -23,7 +23,7 @@ namespace OCSM.CoD.CtL
 		public List<string> Frailties { get; set; }
 		public List<string> Touchstones { get; set; }
 		
-		public Changeling() : base(Constants.GameSystem.CoD.Changeling)
+		public Changeling() : base(Constants.GameSystem.Cofd.Changeling)
 		{
 			Contracts = new List<Contract>();
 			FavoredRegalia = new Pair<Regalia, Regalia>();

--- a/OCSM/scripts/data/cod/ctl/Contract.cs
+++ b/OCSM/scripts/data/cod/ctl/Contract.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
-using OCSM.API;
-using OCSM.Meta;
+using Ocsm.API;
+using Ocsm.Meta;
 
-namespace OCSM.CoD.CtL
+namespace Ocsm.Cofd.Ctl
 {
 	public class Contract : Metadata, IComparable<Contract>, IEmptiable, IEquatable<Contract>
 	{

--- a/OCSM/scripts/data/cod/ctl/ContractRegalia.cs
+++ b/OCSM/scripts/data/cod/ctl/ContractRegalia.cs
@@ -1,7 +1,7 @@
 using System;
-using OCSM.Meta;
+using Ocsm.Meta;
 
-namespace OCSM.CoD.CtL
+namespace Ocsm.Cofd.Ctl
 {
 	public class ContractRegalia : Metadata, IComparable<ContractRegalia>, IEquatable<ContractRegalia>
 	{

--- a/OCSM/scripts/data/cod/ctl/ContractType.cs
+++ b/OCSM/scripts/data/cod/ctl/ContractType.cs
@@ -1,7 +1,7 @@
 using System;
-using OCSM.Meta;
+using Ocsm.Meta;
 
-namespace OCSM.CoD.CtL
+namespace Ocsm.Cofd.Ctl
 {
 	public class ContractType : Metadata, IComparable<ContractType>, IEquatable<ContractType>
 	{

--- a/OCSM/scripts/data/cod/ctl/Court.cs
+++ b/OCSM/scripts/data/cod/ctl/Court.cs
@@ -1,7 +1,7 @@
 using System;
-using OCSM.Meta;
+using Ocsm.Meta;
 
-namespace OCSM.CoD.CtL
+namespace Ocsm.Cofd.Ctl
 {
 	public class Court : Metadata, IEquatable<Court>
 	{

--- a/OCSM/scripts/data/cod/ctl/Kith.cs
+++ b/OCSM/scripts/data/cod/ctl/Kith.cs
@@ -1,7 +1,7 @@
 using System;
-using OCSM.Meta;
+using Ocsm.Meta;
 
-namespace OCSM.CoD.CtL
+namespace Ocsm.Cofd.Ctl
 {
 	public class Kith : Metadata, IEquatable<Kith>
 	{

--- a/OCSM/scripts/data/cod/ctl/Regalia.cs
+++ b/OCSM/scripts/data/cod/ctl/Regalia.cs
@@ -1,7 +1,7 @@
 using System;
-using OCSM.Meta;
+using Ocsm.Meta;
 
-namespace OCSM.CoD.CtL
+namespace Ocsm.Cofd.Ctl
 {
 	public class Regalia : Metadata, IEquatable<Regalia>
 	{

--- a/OCSM/scripts/data/cod/ctl/Seeming.cs
+++ b/OCSM/scripts/data/cod/ctl/Seeming.cs
@@ -1,7 +1,7 @@
 using System;
-using OCSM.Meta;
+using Ocsm.Meta;
 
-namespace OCSM.CoD.CtL
+namespace Ocsm.Cofd.Ctl
 {
 	public class Seeming : Metadata, IEquatable<Seeming>
 	{

--- a/OCSM/scripts/data/cod/ctl/meta/Container.cs
+++ b/OCSM/scripts/data/cod/ctl/meta/Container.cs
@@ -1,16 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using OCSM.Meta;
-using OCSM.CoD.Meta;
+using Ocsm.Meta;
+using Ocsm.Cofd.Meta;
 
-namespace OCSM.CoD.CtL.Meta
+namespace Ocsm.Cofd.Ctl.Meta
 {
-	public class CoDChangelingContainer : CoDCoreContainer, IMetadataContainer, IEquatable<CoDChangelingContainer>
+	public class CofdChangelingContainer : CofdCoreContainer, IMetadataContainer, IEquatable<CofdChangelingContainer>
 	{
-		public static CoDChangelingContainer initializeWithDefaultValues()
+		public static CofdChangelingContainer initializeWithDefaultValues()
 		{
-			var container = new CoDChangelingContainer();
+			var container = new CofdChangelingContainer();
 			
 			container.ContractTypes.Add(new ContractType() { Name = "Common" });
 			container.ContractTypes.Add(new ContractType() { Name = "Royal" });
@@ -58,7 +58,7 @@ namespace OCSM.CoD.CtL.Meta
 		public List<Regalia> Regalias { get; set; }
 		public List<Seeming> Seemings { get; set; }
 		
-		public CoDChangelingContainer() : base()
+		public CofdChangelingContainer() : base()
 		{
 			Contracts = new List<Contract>();
 			ContractTypes = new List<ContractType>();
@@ -70,8 +70,8 @@ namespace OCSM.CoD.CtL.Meta
 		
 		public override void Deserialize(string json)
 		{
-			var result = JsonSerializer.Deserialize<CoDChangelingContainer>(json);
-			if(result is CoDChangelingContainer ccc)
+			var result = JsonSerializer.Deserialize<CofdChangelingContainer>(json);
+			if(result is CofdChangelingContainer ccc)
 			{
 				Contracts = ccc.Contracts;
 				ContractTypes = ccc.ContractTypes;
@@ -99,7 +99,7 @@ namespace OCSM.CoD.CtL.Meta
 			return JsonSerializer.Serialize(this);
 		}
 		
-		public bool Equals(CoDChangelingContainer container)
+		public bool Equals(CofdChangelingContainer container)
 		{
 			return base.Equals(container);
 		}

--- a/OCSM/scripts/data/cod/meta/Container.cs
+++ b/OCSM/scripts/data/cod/meta/Container.cs
@@ -1,18 +1,18 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using OCSM.Meta;
+using Ocsm.Meta;
 
-namespace OCSM.CoD.Meta
+namespace Ocsm.Cofd.Meta
 {
-	public class CoDCoreContainer : IMetadataContainer, IEquatable<CoDCoreContainer>
+	public class CofdCoreContainer : IMetadataContainer, IEquatable<CofdCoreContainer>
 	{
 		public List<Merit> Merits { get; set; } = new List<Merit>();
 		
 		public virtual void Deserialize(string json)
 		{
-			var result = JsonSerializer.Deserialize<CoDCoreContainer>(json);
-			if(result is CoDCoreContainer ccc)
+			var result = JsonSerializer.Deserialize<CofdCoreContainer>(json);
+			if(result is CofdCoreContainer ccc)
 			{
 				Merits = ccc.Merits;
 			}
@@ -28,7 +28,7 @@ namespace OCSM.CoD.Meta
 			return JsonSerializer.Serialize(this);
 		}
 		
-		public bool Equals(CoDCoreContainer container)
+		public bool Equals(CofdCoreContainer container)
 		{
 			return container.Merits.Equals(Merits);
 		}

--- a/OCSM/scripts/data/dnd/fifth/Ability.cs
+++ b/OCSM/scripts/data/dnd/fifth/Ability.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public sealed class Ability : IEquatable<Ability>
 	{

--- a/OCSM/scripts/data/dnd/fifth/Background.cs
+++ b/OCSM/scripts/data/dnd/fifth/Background.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public class Background : Featureful, IComparable<Background>, IEquatable<Background>
 	{

--- a/OCSM/scripts/data/dnd/fifth/Class.cs
+++ b/OCSM/scripts/data/dnd/fifth/Class.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public class Class : Featureful, IComparable<Class>, IEquatable<Class>
 	{

--- a/OCSM/scripts/data/dnd/fifth/CoinPurse.cs
+++ b/OCSM/scripts/data/dnd/fifth/CoinPurse.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public class CoinPurse : IEquatable<CoinPurse>
 	{

--- a/OCSM/scripts/data/dnd/fifth/Currency.cs
+++ b/OCSM/scripts/data/dnd/fifth/Currency.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public enum Currency { Copper, Silver, Electrum, Gold, Platinum }
 	

--- a/OCSM/scripts/data/dnd/fifth/DamageDie.cs
+++ b/OCSM/scripts/data/dnd/fifth/DamageDie.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public class DamageDie : Die, IComparable<DamageDie>, IEquatable<DamageDie>
 	{

--- a/OCSM/scripts/data/dnd/fifth/Die.cs
+++ b/OCSM/scripts/data/dnd/fifth/Die.cs
@@ -1,8 +1,8 @@
 using System;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
-	public class Die : OCSM.Die, IComparable<Die>, IEquatable<Die>
+	public class Die : Ocsm.Die, IComparable<Die>, IEquatable<Die>
 	{
 		public static Die d4 = new Die() { Sides = 4 };
 		public static Die d6 = new Die() { Sides = 6 };

--- a/OCSM/scripts/data/dnd/fifth/Feature.cs
+++ b/OCSM/scripts/data/dnd/fifth/Feature.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using OCSM.Meta;
+using Ocsm.Meta;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public sealed class FeatureType
 	{

--- a/OCSM/scripts/data/dnd/fifth/FifthAdventurer.cs
+++ b/OCSM/scripts/data/dnd/fifth/FifthAdventurer.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using OCSM.DnD.Fifth.Inventory;
+using Ocsm.Dnd.Fifth.Inventory;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public class FifthAdventurer : Character
 	{
@@ -38,7 +38,7 @@ namespace OCSM.DnD.Fifth
 			}
 		}
 		
-		public FifthAdventurer() : base(Constants.GameSystem.DnD.Fifth)
+		public FifthAdventurer() : base(Constants.GameSystem.Dnd.Fifth)
 		{
 			Abilities = Ability.generateBaseAbilityScores();
 			Alignment = String.Empty;

--- a/OCSM/scripts/data/dnd/fifth/HitDice.cs
+++ b/OCSM/scripts/data/dnd/fifth/HitDice.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public class HitDice : IEquatable<HitDice>
 	{

--- a/OCSM/scripts/data/dnd/fifth/HitPoints.cs
+++ b/OCSM/scripts/data/dnd/fifth/HitPoints.cs
@@ -1,5 +1,5 @@
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public class HitPoints
 	{

--- a/OCSM/scripts/data/dnd/fifth/NumericBonus.cs
+++ b/OCSM/scripts/data/dnd/fifth/NumericBonus.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public enum NumericStat
 	{

--- a/OCSM/scripts/data/dnd/fifth/Proficiency.cs
+++ b/OCSM/scripts/data/dnd/fifth/Proficiency.cs
@@ -1,6 +1,6 @@
-using OCSM.Nodes;
+using Ocsm.Nodes;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public enum Proficiency { NoProficiency, HalfProficiency, Proficiency, DoubleProficiency }
 	

--- a/OCSM/scripts/data/dnd/fifth/Race.cs
+++ b/OCSM/scripts/data/dnd/fifth/Race.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public class Race : Featureful, IComparable<Race>, IEquatable<Race>
 	{

--- a/OCSM/scripts/data/dnd/fifth/Range.cs
+++ b/OCSM/scripts/data/dnd/fifth/Range.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public class Range : IComparable<Range>, IEquatable<Range>
 	{

--- a/OCSM/scripts/data/dnd/fifth/Skill.cs
+++ b/OCSM/scripts/data/dnd/fifth/Skill.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace OCSM.DnD.Fifth
+namespace Ocsm.Dnd.Fifth
 {
 	public sealed class Skill : IEquatable<Skill>
 	{

--- a/OCSM/scripts/data/dnd/fifth/inventory/Equipment.cs
+++ b/OCSM/scripts/data/dnd/fifth/inventory/Equipment.cs
@@ -1,5 +1,5 @@
 
-namespace OCSM.DnD.Fifth.Inventory
+namespace Ocsm.Dnd.Fifth.Inventory
 {
 	public class Equipment
 	{

--- a/OCSM/scripts/data/dnd/fifth/inventory/Item.cs
+++ b/OCSM/scripts/data/dnd/fifth/inventory/Item.cs
@@ -1,7 +1,7 @@
 using System;
-using OCSM.Meta;
+using Ocsm.Meta;
 
-namespace OCSM.DnD.Fifth.Inventory
+namespace Ocsm.Dnd.Fifth.Inventory
 {
 	public class Item : Metadata, IComparable<Item>, IEquatable<Item>
 	{

--- a/OCSM/scripts/data/dnd/fifth/inventory/ItemArmor.cs
+++ b/OCSM/scripts/data/dnd/fifth/inventory/ItemArmor.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace OCSM.DnD.Fifth.Inventory
+namespace Ocsm.Dnd.Fifth.Inventory
 {
 	public class ItemArmor : ItemEquippable, IComparable<ItemArmor>, IEquatable<ItemArmor>
 	{

--- a/OCSM/scripts/data/dnd/fifth/inventory/ItemContainer.cs
+++ b/OCSM/scripts/data/dnd/fifth/inventory/ItemContainer.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace OCSM.DnD.Fifth.Inventory
+namespace Ocsm.Dnd.Fifth.Inventory
 {
 	public class ItemContainer : ItemEquippable, IComparable<ItemContainer>, IEquatable<ItemContainer>
 	{

--- a/OCSM/scripts/data/dnd/fifth/inventory/ItemEquippable.cs
+++ b/OCSM/scripts/data/dnd/fifth/inventory/ItemEquippable.cs
@@ -1,7 +1,7 @@
 using System;
-using OCSM.Meta;
+using Ocsm.Meta;
 
-namespace OCSM.DnD.Fifth.Inventory
+namespace Ocsm.Dnd.Fifth.Inventory
 {
 	public class ItemEquippable : Item, IComparable<ItemEquippable>, IEquatable<ItemEquippable>
 	{

--- a/OCSM/scripts/data/dnd/fifth/inventory/ItemWeapon.cs
+++ b/OCSM/scripts/data/dnd/fifth/inventory/ItemWeapon.cs
@@ -2,7 +2,7 @@ using System;
 using System.Text;
 using System.Collections.Generic;
 
-namespace OCSM.DnD.Fifth.Inventory
+namespace Ocsm.Dnd.Fifth.Inventory
 {
 	public class ItemWeapon : ItemEquippable, IComparable<ItemWeapon>, IEquatable<ItemWeapon>
 	{

--- a/OCSM/scripts/data/dnd/fifth/meta/Container.cs
+++ b/OCSM/scripts/data/dnd/fifth/meta/Container.cs
@@ -2,12 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using OCSM.Meta;
-using OCSM.DnD.Fifth.Inventory;
+using Ocsm.Meta;
+using Ocsm.Dnd.Fifth.Inventory;
 
-namespace OCSM.DnD.Fifth.Meta
+namespace Ocsm.Dnd.Fifth.Meta
 {
-	public class DnDFifthContainer : IMetadataContainer, IEquatable<DnDFifthContainer>
+	public class DndFifthContainer : IMetadataContainer, IEquatable<DndFifthContainer>
 	{
 		[JsonIgnore]
 		public List<Item> AllItems
@@ -35,8 +35,8 @@ namespace OCSM.DnD.Fifth.Meta
 		
 		public void Deserialize(string json)
 		{
-			var result = JsonSerializer.Deserialize<DnDFifthContainer>(json);
-			if(result is DnDFifthContainer dfc)
+			var result = JsonSerializer.Deserialize<DndFifthContainer>(json);
+			if(result is DndFifthContainer dfc)
 			{
 				dfc.Sort();
 				
@@ -80,7 +80,7 @@ namespace OCSM.DnD.Fifth.Meta
 			Weapons.Sort();
 		}
 		
-		public bool Equals(DnDFifthContainer container)
+		public bool Equals(DndFifthContainer container)
 		{
 			return Armors.Equals(container.Armors)
 				&& Backgrounds.Equals(container.Backgrounds)

--- a/OCSM/scripts/data/dnd/fifth/meta/Featureful.cs
+++ b/OCSM/scripts/data/dnd/fifth/meta/Featureful.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using OCSM.Meta;
+using Ocsm.Meta;
 
-namespace OCSM.DnD.Fifth.Meta
+namespace Ocsm.Dnd.Fifth.Meta
 {
 	public abstract class Featureful : Metadata,  IComparable<Featureful>, IEquatable<Featureful>
 	{

--- a/OCSM/scripts/data/dnd/fifth/meta/SpellSlotTable.cs
+++ b/OCSM/scripts/data/dnd/fifth/meta/SpellSlotTable.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace OCSM.DnD.Fifth.Meta
+namespace Ocsm.Dnd.Fifth.Meta
 {
 	public sealed class SpellSlots
 	{

--- a/OCSM/scripts/data/meta/Metadata.cs
+++ b/OCSM/scripts/data/meta/Metadata.cs
@@ -1,7 +1,7 @@
 using Godot;
 using System;
 
-namespace OCSM.Meta
+namespace Ocsm.Meta
 {
 	public interface IMetadataContainer
 	{

--- a/OCSM/scripts/interface/ConfirmQuit.cs
+++ b/OCSM/scripts/interface/ConfirmQuit.cs
@@ -1,7 +1,7 @@
 using Godot;
-using OCSM.Nodes.Autoload;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class ConfirmQuit : ConfirmationDialog
 	{

--- a/OCSM/scripts/interface/OpenSheet.cs
+++ b/OCSM/scripts/interface/OpenSheet.cs
@@ -2,7 +2,7 @@ using Godot;
 using System;
 using System.Collections.Generic;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class OpenSheet : FileDialog
 	{

--- a/OCSM/scripts/interface/SaveSheet.cs
+++ b/OCSM/scripts/interface/SaveSheet.cs
@@ -1,7 +1,7 @@
 using Godot;
 using System;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class SaveSheet : FileDialog
 	{

--- a/OCSM/scripts/interface/menu/FileMenu.cs
+++ b/OCSM/scripts/interface/menu/FileMenu.cs
@@ -1,7 +1,7 @@
 using Godot;
-using OCSM.Nodes.Autoload;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class FileMenu : MenuButton
 	{

--- a/OCSM/scripts/interface/menu/HelpMenu.cs
+++ b/OCSM/scripts/interface/menu/HelpMenu.cs
@@ -1,12 +1,12 @@
 using Godot;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class HelpMenu : MenuButton
 	{
 		private sealed class ItemNames
 		{
-			public const string About = "About OCSM";
+			public const string About = "About Ocsm";
 			public const string GameSystemLicenses = "Game System Licences";
 			public const string Godot = "About Godot Engine";
 		}
@@ -50,7 +50,7 @@ namespace OCSM.Nodes
 				aboutOcsm.PopupCentered();
 			else
 			{
-				var resource = GD.Load<PackedScene>(Constants.Scene.AboutOCSM);
+				var resource = GD.Load<PackedScene>(Constants.Scene.AboutOcsm);
 				aboutOcsm = resource.Instantiate<Window>();
 				aboutOcsm.CloseRequested += () => NodeUtilities.queueFree(ref aboutOcsm);
 				

--- a/OCSM/scripts/interface/menu/MetadataMenu.cs
+++ b/OCSM/scripts/interface/menu/MetadataMenu.cs
@@ -1,10 +1,10 @@
 using Godot;
-using OCSM.Nodes.Autoload;
-using OCSM.Nodes.CoD.CtL.Meta;
-using OCSM.Nodes.DnD.Fifth.Meta;
-using OCSM.Nodes.Meta;
+using Ocsm.Nodes.Autoload;
+using Ocsm.Nodes.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Dnd.Fifth.Meta;
+using Ocsm.Nodes.Meta;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class MetadataMenu : MenuButton
 	{
@@ -42,11 +42,11 @@ namespace OCSM.Nodes
 		{
 			switch(metadataManager.CurrentGameSystem)
 			{
-				case Constants.GameSystem.CoD.Changeling:
-					generatePopup<CodChangelingAddEditMetadata>(GD.Load<PackedScene>(Constants.Scene.CoD.Changeling.Meta.AddEditMetadata));
+				case Constants.GameSystem.Cofd.Changeling:
+					generatePopup<CodChangelingAddEditMetadata>(GD.Load<PackedScene>(Constants.Scene.Cofd.Changeling.Meta.AddEditMetadata));
 					break;
-				case Constants.GameSystem.DnD.Fifth:
-					generatePopup<DndFifthAddEditMetadata>(GD.Load<PackedScene>(Constants.Scene.DnD.Fifth.Meta.AddEditMetadata));
+				case Constants.GameSystem.Dnd.Fifth:
+					generatePopup<DndFifthAddEditMetadata>(GD.Load<PackedScene>(Constants.Scene.Dnd.Fifth.Meta.AddEditMetadata));
 					break;
 				default:
 					break;

--- a/OCSM/scripts/nodes/AppRoot.cs
+++ b/OCSM/scripts/nodes/AppRoot.cs
@@ -1,7 +1,7 @@
 using Godot;
-using OCSM.Nodes.Autoload;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class AppRoot : Control
 	{

--- a/OCSM/scripts/nodes/ClickableControl.cs
+++ b/OCSM/scripts/nodes/ClickableControl.cs
@@ -1,7 +1,7 @@
 using Godot;
-using OCSM.Nodes.Autoload;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class ClickableControl : Control
 	{

--- a/OCSM/scripts/nodes/CustomOption.cs
+++ b/OCSM/scripts/nodes/CustomOption.cs
@@ -1,9 +1,9 @@
 using Godot;
 using System;
 using System.Collections.Generic;
-using OCSM.Nodes.Autoload;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public abstract partial class CustomOption : OptionButton
 	{

--- a/OCSM/scripts/nodes/EntryList.cs
+++ b/OCSM/scripts/nodes/EntryList.cs
@@ -3,7 +3,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class EntryList : Container
 	{

--- a/OCSM/scripts/nodes/ICanDelete.cs
+++ b/OCSM/scripts/nodes/ICanDelete.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public interface ICanDelete
 	{

--- a/OCSM/scripts/nodes/NewSheet.cs
+++ b/OCSM/scripts/nodes/NewSheet.cs
@@ -1,7 +1,7 @@
 using Godot;
-using OCSM.Nodes.Autoload;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class NewSheet : ScrollContainer
 	{
@@ -32,14 +32,14 @@ namespace OCSM.Nodes
 			sheetManager = GetNode<SheetManager>(Constants.NodePath.SheetManager);
 			tabContainer = GetNode<TabContainer>(AppRoot.NodePath.SheetTabs);
 			
-			GetNode<Button>(NodePath.CodMortal2e).Pressed += newCoDMortal2e;
-			GetNode<Button>(NodePath.CodChangeling2e).Pressed += newCoDChangeling2e;
+			GetNode<Button>(NodePath.CodMortal2e).Pressed += newCofdMortal2e;
+			GetNode<Button>(NodePath.CodChangeling2e).Pressed += newCofdChangeling2e;
 			GetNode<Button>(NodePath.Dnd5thPath).Pressed += newDnd5e;
 		}
 		
-		private void newCoDMortal2e() { addSheet(Constants.Scene.CoD.Mortal.Sheet, Constants.Scene.CoD.Mortal.NewSheetName); }
-		private void newCoDChangeling2e() { addSheet(Constants.Scene.CoD.Changeling.Sheet, Constants.Scene.CoD.Changeling.NewSheetName); }
-		private void newDnd5e() { addSheet(Constants.Scene.DnD.Fifth.Sheet, Constants.Scene.DnD.Fifth.NewSheetName); }
+		private void newCofdMortal2e() { addSheet(Constants.Scene.Cofd.Mortal.Sheet, Constants.Scene.Cofd.Mortal.NewSheetName); }
+		private void newCofdChangeling2e() { addSheet(Constants.Scene.Cofd.Changeling.Sheet, Constants.Scene.Cofd.Changeling.NewSheetName); }
+		private void newDnd5e() { addSheet(Constants.Scene.Dnd.Fifth.Sheet, Constants.Scene.Dnd.Fifth.NewSheetName); }
 		
 		private void addSheet(string sheetPath, string name)
 		{

--- a/OCSM/scripts/nodes/StatefulButton.cs
+++ b/OCSM/scripts/nodes/StatefulButton.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class StatefulButton : TextureButton
 	{

--- a/OCSM/scripts/nodes/ToggleButton.cs
+++ b/OCSM/scripts/nodes/ToggleButton.cs
@@ -1,7 +1,7 @@
 using Godot;
 using System;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class ToggleButton : TextureButton
 	{

--- a/OCSM/scripts/nodes/TrackComplex.cs
+++ b/OCSM/scripts/nodes/TrackComplex.cs
@@ -1,7 +1,7 @@
 using Godot;
 using System.Collections.Generic;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class TrackComplex : GridContainer
 	{

--- a/OCSM/scripts/nodes/TrackSimple.cs
+++ b/OCSM/scripts/nodes/TrackSimple.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace OCSM.Nodes
+namespace Ocsm.Nodes
 {
 	public partial class TrackSimple : GridContainer
 	{

--- a/OCSM/scripts/nodes/cod/AttributeOptionButton.cs
+++ b/OCSM/scripts/nodes/cod/AttributeOptionButton.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 
-namespace OCSM.Nodes.CoD
+namespace Ocsm.Nodes.Cofd
 {
 	public partial class AttributeOptionButton : CustomOption
 	{
@@ -12,7 +12,7 @@ namespace OCSM.Nodes.CoD
 		
 		protected override void refreshMetadata()
 		{
-			replaceItems(Enum.GetValues<OCSM.CoD.Attribute.Enum>()
+			replaceItems(Enum.GetValues<Ocsm.Cofd.Attribute.Enum>()
 				.Select(a => a.GetLabelOrName())
 				.ToList());
 		}

--- a/OCSM/scripts/nodes/cod/ItemDotsList.cs
+++ b/OCSM/scripts/nodes/cod/ItemDotsList.cs
@@ -3,7 +3,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 
-namespace OCSM.Nodes.CoD
+namespace Ocsm.Nodes.Cofd
 {
 	public partial class ItemDotsList : Container
 	{
@@ -53,7 +53,7 @@ namespace OCSM.Nodes.CoD
 		
 		protected virtual void addInput(string text = "", long dots = 0)
 		{
-			var resource = GD.Load<PackedScene>(Constants.Scene.CoD.ItemDots);
+			var resource = GD.Load<PackedScene>(Constants.Scene.Cofd.ItemDots);
 			var node = resource.Instantiate();
 			var textEdit = node.GetChild<TextEdit>(0);
 			textEdit.Text = text;

--- a/OCSM/scripts/nodes/cod/MeritList.cs
+++ b/OCSM/scripts/nodes/cod/MeritList.cs
@@ -2,9 +2,9 @@ using Godot;
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using OCSM.CoD;
+using Ocsm.Cofd;
 
-namespace OCSM.Nodes.CoD
+namespace Ocsm.Nodes.Cofd
 {
 	public partial class MeritList : ItemDotsList
 	{

--- a/OCSM/scripts/nodes/cod/SkillOptionButton.cs
+++ b/OCSM/scripts/nodes/cod/SkillOptionButton.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 
-namespace OCSM.Nodes.CoD
+namespace Ocsm.Nodes.Cofd
 {
 	public partial class SkillOptionButton : CustomOption
 	{
@@ -12,7 +12,7 @@ namespace OCSM.Nodes.CoD
 		
 		protected override void refreshMetadata()
 		{
-			replaceItems(Enum.GetValues<OCSM.CoD.Skill.Enum>()
+			replaceItems(Enum.GetValues<Ocsm.Cofd.Skill.Enum>()
 				.Select(s => s.GetLabelOrName())
 				.ToList());
 		}

--- a/OCSM/scripts/nodes/cod/SpecialtyList.cs
+++ b/OCSM/scripts/nodes/cod/SpecialtyList.cs
@@ -2,9 +2,9 @@ using Godot;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OCSM.CoD;
+using Ocsm.Cofd;
 
-namespace OCSM.Nodes.CoD
+namespace Ocsm.Nodes.Cofd
 {
 	public partial class SpecialtyList : Container
 	{
@@ -94,7 +94,7 @@ namespace OCSM.Nodes.CoD
 		
 		private void addInput(Skill.Enum? skill = null, string specialty = "")
 		{
-			var resource = GD.Load<PackedScene>(Constants.Scene.CoD.Specialty);
+			var resource = GD.Load<PackedScene>(Constants.Scene.Cofd.Specialty);
 			var instance = resource.Instantiate<HBoxContainer>();
 			AddChild(instance);
 			

--- a/OCSM/scripts/nodes/cod/Weapon.cs
+++ b/OCSM/scripts/nodes/cod/Weapon.cs
@@ -1,7 +1,7 @@
 using Godot;
-using OCSM.CoD;
+using Ocsm.Cofd;
 
-namespace OCSM.Nodes.CoD
+namespace Ocsm.Nodes.Cofd
 {
 	public partial class Weapon : VBoxContainer
 	{

--- a/OCSM/scripts/nodes/cod/ctl/ContractNode.cs
+++ b/OCSM/scripts/nodes/cod/ctl/ContractNode.cs
@@ -2,12 +2,12 @@ using Godot;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OCSM.CoD;
-using OCSM.CoD.CtL;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Autoload;
+using Ocsm.Cofd;
+using Ocsm.Cofd.Ctl;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes.CoD.CtL
+namespace Ocsm.Nodes.Cofd.Ctl
 {
 	public partial class ContractNode : MarginContainer
 	{
@@ -116,7 +116,7 @@ namespace OCSM.Nodes.CoD.CtL
 			refreshSeemingBenefits();
 		}
 		
-		public OCSM.CoD.CtL.Contract getData()
+		public Ocsm.Cofd.Ctl.Contract getData()
 		{
 			var attr1Node = GetNode<AttributeOptionButton>(NodePath.AttributeInput);
 			var regaliaNode = GetNode<ContractRegaliaOptionButton>(NodePath.RegaliaInput);
@@ -136,9 +136,9 @@ namespace OCSM.Nodes.CoD.CtL
 			var actionNode = GetNode<OptionButton>(NodePath.ActionInput);
 			var action = actionNode.GetSelectedItemText();
 			
-			var attribute = OCSM.CoD.Attribute.KindFromString(attr1Node.GetSelectedItemText());
-			var attributeContested = OCSM.CoD.Attribute.KindFromString(attribute3Input.GetSelectedItemText());
-			var attributeResisted = OCSM.CoD.Attribute.KindFromString(attribute2Input.GetSelectedItemText());
+			var attribute = Ocsm.Cofd.Attribute.KindFromString(attr1Node.GetSelectedItemText());
+			var attributeContested = Ocsm.Cofd.Attribute.KindFromString(attribute3Input.GetSelectedItemText());
+			var attributeResisted = Ocsm.Cofd.Attribute.KindFromString(attribute2Input.GetSelectedItemText());
 			var skill = Skill.KindFromString(skillInput.GetSelectedItemText());
 			var regalia = regaliaNode.GetSelectedItemText();
 			var contractType = contractTypeNode.GetSelectedItemText();
@@ -147,7 +147,7 @@ namespace OCSM.Nodes.CoD.CtL
 			
 			ContractRegalia regaliaObj = null;
 			ContractType contractTypeObj = null;
-			if(metadataManager.Container is CoDChangelingContainer ccc2)
+			if(metadataManager.Container is CofdChangelingContainer ccc2)
 			{
 				if(ccc2.Regalias.Find(r => r.Name.Equals(regalia)) is Regalia r)
 					regaliaObj = ContractRegalia.From(r);
@@ -160,7 +160,7 @@ namespace OCSM.Nodes.CoD.CtL
 			if(!(regaliaObj is ContractRegalia) && regalia.Equals(ContractRegalia.Goblin.Name))
 				regaliaObj = ContractRegalia.Goblin;
 			
-			return new OCSM.CoD.CtL.Contract()
+			return new Ocsm.Cofd.Ctl.Contract()
 			{
 				Action = action,
 				Attribute = attribute,
@@ -183,18 +183,18 @@ namespace OCSM.Nodes.CoD.CtL
 			};
 		}
 		
-		public void setData(OCSM.CoD.CtL.Contract contract)
+		public void setData(Ocsm.Cofd.Ctl.Contract contract)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				var attribute1 = GetNode<AttributeOptionButton>(NodePath.AttributeInput);
-				if(contract.Attribute is OCSM.CoD.Attribute.Enum)
+				if(contract.Attribute is Ocsm.Cofd.Attribute.Enum)
 					attribute1.SelectItemByText(contract.Attribute.ToString());
-				if(contract.AttributeContested is OCSM.CoD.Attribute.Enum)
+				if(contract.AttributeContested is Ocsm.Cofd.Attribute.Enum)
 					attribute2Input.SelectItemByText(contract.AttributeContested.ToString());
-				if(contract.AttributeResisted is OCSM.CoD.Attribute.Enum)
+				if(contract.AttributeResisted is Ocsm.Cofd.Attribute.Enum)
 					attribute3Input.SelectItemByText(contract.AttributeResisted.ToString());
-				if(contract.Skill is OCSM.CoD.Skill.Enum)
+				if(contract.Skill is Ocsm.Cofd.Skill.Enum)
 					skillInput.SelectItemByText(contract.Skill.GetLabelOrName());
 				if(contract.Regalia is ContractRegalia)
 					GetNode<ContractRegaliaOptionButton>(NodePath.RegaliaInput).SelectItemByText(contract.Regalia.Name);
@@ -337,7 +337,7 @@ namespace OCSM.Nodes.CoD.CtL
 		
 		private void addSeemingBenefitInput(string seeming = null, string benefit = "")
 		{
-			var resource = GD.Load<PackedScene>(Constants.Scene.CoD.Changeling.SeemingBenefit);
+			var resource = GD.Load<PackedScene>(Constants.Scene.Cofd.Changeling.SeemingBenefit);
 			var instance = resource.Instantiate<HBoxContainer>();
 			seemingBenefitsRow.AddChild(instance);
 			

--- a/OCSM/scripts/nodes/cod/ctl/ContractsList.cs
+++ b/OCSM/scripts/nodes/cod/ctl/ContractsList.cs
@@ -2,12 +2,12 @@ using Godot;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OCSM.CoD;
-using OCSM.CoD.CtL;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Autoload;
+using Ocsm.Cofd;
+using Ocsm.Cofd.Ctl;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes.CoD.CtL
+namespace Ocsm.Nodes.Cofd.Ctl
 {
 	public partial class ContractsList : Container
 	{
@@ -64,7 +64,7 @@ namespace OCSM.Nodes.CoD.CtL
 		
 		private void addInput(Contract value = null)
 		{
-			var resource = GD.Load<PackedScene>(Constants.Scene.CoD.Changeling.ContractNode);
+			var resource = GD.Load<PackedScene>(Constants.Scene.Cofd.Changeling.ContractNode);
 			var instance = resource.Instantiate<ContractNode>();
 			
 			AddChild(instance);
@@ -75,17 +75,17 @@ namespace OCSM.Nodes.CoD.CtL
 				actionNode.SelectItemByText(value.Action);
 				instance.actionChanged(actionNode.Selected);
 				
-				if(value.Attribute is OCSM.CoD.Attribute.Enum attribute)
+				if(value.Attribute is Ocsm.Cofd.Attribute.Enum attribute)
 				{
 					var node = instance.GetNode<AttributeOptionButton>(ContractNode.NodePath.AttributeInput);
 					node.SelectItemByText(attribute.ToString());
 					instance.attributeChanged(node.Selected);
 				}
 				
-				if(value.AttributeResisted is OCSM.CoD.Attribute.Enum attributeResisted)
+				if(value.AttributeResisted is Ocsm.Cofd.Attribute.Enum attributeResisted)
 					instance.GetNode<AttributeOptionButton>(ContractNode.NodePath.Attribute2Input).SelectItemByText(attributeResisted.ToString());
 				
-				if(value.AttributeContested is OCSM.CoD.Attribute.Enum attributeContested)
+				if(value.AttributeContested is Ocsm.Cofd.Attribute.Enum attributeContested)
 				{
 					var node = instance.GetNode<AttributeOptionButton>(ContractNode.NodePath.Attribute3Input);
 					node.SelectItemByText(attributeContested.ToString());
@@ -114,7 +114,7 @@ namespace OCSM.Nodes.CoD.CtL
 				if(value.Skill is Skill.Enum skill)
 					instance.GetNode<SkillOptionButton>(ContractNode.NodePath.SkillInput).SelectItemByText(skill.GetLabelOrName());
 				
-				if(metadataManager.Container is CoDChangelingContainer ccc)
+				if(metadataManager.Container is CofdChangelingContainer ccc)
 				{
 					if(value.Regalia is ContractRegalia)
 						instance.GetNode<ContractRegaliaOptionButton>(ContractNode.NodePath.RegaliaInput).SelectItemByText(value.Regalia.Name);

--- a/OCSM/scripts/nodes/cod/ctl/meta/CodChangelingAddEditMetadata.cs
+++ b/OCSM/scripts/nodes/cod/ctl/meta/CodChangelingAddEditMetadata.cs
@@ -1,12 +1,12 @@
 using Godot;
-using OCSM.CoD;
-using OCSM.CoD.CtL;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Autoload;
-using OCSM.Nodes.CoD.Meta;
-using OCSM.Nodes.Meta;
+using Ocsm.Cofd;
+using Ocsm.Cofd.Ctl;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Autoload;
+using Ocsm.Nodes.Cofd.Meta;
+using Ocsm.Nodes.Meta;
 
-namespace OCSM.Nodes.CoD.CtL.Meta
+namespace Ocsm.Nodes.Cofd.Ctl.Meta
 {
 	public partial class CodChangelingAddEditMetadata : BaseAddEditMetadata
 	{
@@ -67,9 +67,9 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void deleteContract(string name)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
-				if(ccc.Contracts.Find(c => c.Name.Equals(name)) is OCSM.CoD.CtL.Contract contract)
+				if(ccc.Contracts.Find(c => c.Name.Equals(name)) is Ocsm.Cofd.Ctl.Contract contract)
 				{
 					ccc.Contracts.Remove(contract);
 					EmitSignal(nameof(MetadataChanged));
@@ -79,7 +79,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void deleteContractType(string name)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.ContractTypes.Find(ct => ct.Name.Equals(name)) is ContractType contractType)
 				{
@@ -91,7 +91,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void deleteCourt(string name)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Courts.Find(c => c.Name.Equals(name)) is Court court)
 				{
@@ -103,7 +103,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void deleteKith(string name)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Kiths.Find(k => k.Name.Equals(name)) is Kith kith)
 				{
@@ -115,7 +115,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void deleteMerit(string name)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Merits.Find(m => m.Name.Equals(name)) is Merit merit)
 				{
@@ -127,7 +127,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void deleteRegalia(string name)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Regalias.Find(r => r.Name.Equals(name)) is Regalia regalia)
 				{
@@ -139,7 +139,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void deleteSeeming(string name)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Seemings.Find(s => s.Name.Equals(name)) is Seeming seeming)
 				{
@@ -151,12 +151,12 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void saveContract()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				var entry = GetNode<ContractEntry>(NodePath.ContractName);
 				var contract = entry.GetNode<ContractNode>(ContractEntry.NodePath.ContractInput).getData();
 				
-				if(ccc.Contracts.Find(c => c.Name.Equals(contract.Name)) is OCSM.CoD.CtL.Contract existingContract)
+				if(ccc.Contracts.Find(c => c.Name.Equals(contract.Name)) is Ocsm.Cofd.Ctl.Contract existingContract)
 					ccc.Contracts.Remove(existingContract);
 				
 				ccc.Contracts.Add(contract);
@@ -166,7 +166,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void saveContractType(string name, string description)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.ContractTypes.Find(ct => ct.Name.Equals(name)) is ContractType contractType)
 					ccc.ContractTypes.Remove(contractType);
@@ -178,7 +178,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void saveCourt(string name, string description)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Courts.Find(c => c.Name.Equals(name)) is Court court)
 					ccc.Courts.Remove(court);
@@ -190,7 +190,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void saveKith(string name, string description)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Kiths.Find(k => k.Name.Equals(name)) is Kith kith)
 					ccc.Kiths.Remove(kith);
@@ -202,7 +202,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void saveMerit(string name, string description, int value)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Merits.Find(m => m.Name.Equals(name)) is Merit merit)
 					ccc.Merits.Remove(merit);
@@ -214,7 +214,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void saveRegalia(string name, string description)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Regalias.Find(r => r.Name.Equals(name)) is Regalia regalia)
 					ccc.Regalias.Remove(regalia);
@@ -226,7 +226,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void saveSeeming(string name, string description)
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Seemings.Find(s => s.Name.Equals(name)) is Seeming seeming)
 					ccc.Seemings.Remove(seeming);

--- a/OCSM/scripts/nodes/cod/ctl/meta/ContractEntry.cs
+++ b/OCSM/scripts/nodes/cod/ctl/meta/ContractEntry.cs
@@ -1,11 +1,11 @@
 using Godot;
 using System;
-using OCSM.CoD.CtL;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Autoload;
-using OCSM.Nodes.Meta;
+using Ocsm.Cofd.Ctl;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Autoload;
+using Ocsm.Nodes.Meta;
 
-namespace OCSM.Nodes.CoD.CtL.Meta
+namespace Ocsm.Nodes.Cofd.Ctl.Meta
 {
 	public partial class ContractEntry : Container
 	{
@@ -44,7 +44,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 			refreshMetadata();
 		}
 		
-		public void loadContract(OCSM.CoD.CtL.Contract contract)
+		public void loadContract(Ocsm.Cofd.Ctl.Contract contract)
 		{
 			var contractInput = GetNode<ContractNode>(NodePath.ContractInput);
 			contractInput.setData(contract);
@@ -85,9 +85,9 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 			if(name.Contains(" ("))
 				name = name.Substring(0, name.IndexOf(" ("));
 			
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
-				if(ccc.Contracts.Find(c => c.Name.Equals(name)) is OCSM.CoD.CtL.Contract contract)
+				if(ccc.Contracts.Find(c => c.Name.Equals(name)) is Ocsm.Cofd.Ctl.Contract contract)
 				{
 					loadContract(contract);
 					optionButton.Deselect();
@@ -95,7 +95,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 			}
 		}
 		
-		private string generateEntryName(OCSM.CoD.CtL.Contract contract)
+		private string generateEntryName(Ocsm.Cofd.Ctl.Contract contract)
 		{
 			var ct = String.Empty;
 			var r = String.Empty;
@@ -133,7 +133,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void refreshMetadata()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				var optionButton = GetNode<OptionButton>(NodePath.ExistingEntryName);
 				optionButton.Clear();

--- a/OCSM/scripts/nodes/cod/ctl/meta/ContractTypeEntry.cs
+++ b/OCSM/scripts/nodes/cod/ctl/meta/ContractTypeEntry.cs
@@ -1,10 +1,10 @@
 using Godot;
 using System;
-using OCSM.CoD.CtL;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Meta;
+using Ocsm.Cofd.Ctl;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Meta;
 
-namespace OCSM.Nodes.CoD.CtL.Meta
+namespace Ocsm.Nodes.Cofd.Ctl.Meta
 {
 	public partial class ContractTypeEntry : BasicMetadataEntry
 	{
@@ -12,7 +12,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		{
 			var optionsButton = GetNode<OptionButton>(NodePath.ExistingEntryName);
 			var name = optionsButton.GetItemText((int)index);
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.ContractTypes.Find(ct => ct.Name.Equals(name)) is ContractType contractType)
 				{
@@ -24,7 +24,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		public override void refreshMetadata()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				var optionButton = GetNode<OptionButton>(NodePath.ExistingEntryName);
 				optionButton.Clear();

--- a/OCSM/scripts/nodes/cod/ctl/meta/CourtEntry.cs
+++ b/OCSM/scripts/nodes/cod/ctl/meta/CourtEntry.cs
@@ -1,10 +1,10 @@
 using Godot;
 using System;
-using OCSM.CoD.CtL;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Meta;
+using Ocsm.Cofd.Ctl;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Meta;
 
-namespace OCSM.Nodes.CoD.CtL.Meta
+namespace Ocsm.Nodes.Cofd.Ctl.Meta
 {
 	public partial class CourtEntry : BasicMetadataEntry
 	{
@@ -12,7 +12,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		{
 			var optionsButton = GetNode<OptionButton>(NodePath.ExistingEntryName);
 			var name = optionsButton.GetItemText((int)index);
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Courts.Find(c => c.Name.Equals(name)) is Court court)
 				{
@@ -24,7 +24,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		public override void refreshMetadata()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				var optionButton = GetNode<OptionButton>(NodePath.ExistingEntryName);
 				optionButton.Clear();

--- a/OCSM/scripts/nodes/cod/ctl/meta/KithEntry.cs
+++ b/OCSM/scripts/nodes/cod/ctl/meta/KithEntry.cs
@@ -1,10 +1,10 @@
 using Godot;
 using System;
-using OCSM.CoD.CtL;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Meta;
+using Ocsm.Cofd.Ctl;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Meta;
 
-namespace OCSM.Nodes.CoD.CtL.Meta
+namespace Ocsm.Nodes.Cofd.Ctl.Meta
 {
 	public partial class KithEntry : BasicMetadataEntry
 	{
@@ -12,7 +12,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		{
 			var optionsButton = GetNode<OptionButton>(NodePath.ExistingEntryName);
 			var name = optionsButton.GetItemText((int)index);
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Kiths.Find(k => k.Name.Equals(name)) is Kith kith)
 				{
@@ -24,7 +24,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		public override void refreshMetadata()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				var optionButton = GetNode<OptionButton>(NodePath.ExistingEntryName);
 				optionButton.Clear();

--- a/OCSM/scripts/nodes/cod/ctl/meta/MeritsFromMetadata.cs
+++ b/OCSM/scripts/nodes/cod/ctl/meta/MeritsFromMetadata.cs
@@ -1,9 +1,9 @@
 using Godot;
 using System;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Autoload;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes.CoD.CtL.Meta
+namespace Ocsm.Nodes.Cofd.Ctl.Meta
 {
 	public partial class MeritsFromMetadata : Container
 	{
@@ -31,7 +31,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		private void refreshMerits()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				var optionButton = GetNode<OptionButton>(NodePath.MeritsName);
 				optionButton.Clear();

--- a/OCSM/scripts/nodes/cod/ctl/meta/RegaliaEntry.cs
+++ b/OCSM/scripts/nodes/cod/ctl/meta/RegaliaEntry.cs
@@ -1,10 +1,10 @@
 using Godot;
 using System;
-using OCSM.CoD.CtL;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Meta;
+using Ocsm.Cofd.Ctl;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Meta;
 
-namespace OCSM.Nodes.CoD.CtL.Meta
+namespace Ocsm.Nodes.Cofd.Ctl.Meta
 {
 	public partial class RegaliaEntry : BasicMetadataEntry
 	{
@@ -12,7 +12,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		{
 			var optionsButton = GetNode<OptionButton>(NodePath.ExistingEntryName);
 			var name = optionsButton.GetItemText((int)index);
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Regalias.Find(r => r.Name.Equals(name)) is Regalia regalia)
 				{
@@ -24,7 +24,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		public override void refreshMetadata()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				var optionButton = GetNode<OptionButton>(NodePath.ExistingEntryName);
 				optionButton.Clear();

--- a/OCSM/scripts/nodes/cod/ctl/meta/SeemingEntry.cs
+++ b/OCSM/scripts/nodes/cod/ctl/meta/SeemingEntry.cs
@@ -1,10 +1,10 @@
 using Godot;
 using System;
-using OCSM.CoD.CtL;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Meta;
+using Ocsm.Cofd.Ctl;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Meta;
 
-namespace OCSM.Nodes.CoD.CtL.Meta
+namespace Ocsm.Nodes.Cofd.Ctl.Meta
 {
 	public partial class SeemingEntry : BasicMetadataEntry
 	{
@@ -12,7 +12,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		{
 			var optionsButton = GetNode<OptionButton>(NodePath.ExistingEntryName);
 			var name = optionsButton.GetItemText((int)index);
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Seemings.Find(s => s.Name.Equals(name)) is Seeming seeming)
 				{
@@ -24,7 +24,7 @@ namespace OCSM.Nodes.CoD.CtL.Meta
 		
 		public override void refreshMetadata()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				var optionButton = GetNode<OptionButton>(NodePath.ExistingEntryName);
 				optionButton.Clear();

--- a/OCSM/scripts/nodes/cod/ctl/options/ActionOptionButton.cs
+++ b/OCSM/scripts/nodes/cod/ctl/options/ActionOptionButton.cs
@@ -2,7 +2,7 @@ using Godot;
 using System;
 using System.Linq;
 
-namespace OCSM.Nodes.CoD.CtL
+namespace Ocsm.Nodes.Cofd.Ctl
 {
 	public partial class ActionOptionButton : CustomOption
 	{

--- a/OCSM/scripts/nodes/cod/ctl/options/ContractRegaliaOptionButton.cs
+++ b/OCSM/scripts/nodes/cod/ctl/options/ContractRegaliaOptionButton.cs
@@ -1,9 +1,9 @@
 using System.Linq;
-using OCSM.CoD.CtL;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Autoload;
+using Ocsm.Cofd.Ctl;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes.CoD.CtL
+namespace Ocsm.Nodes.Cofd.Ctl
 {
 	public partial class ContractRegaliaOptionButton : CustomOption
 	{
@@ -18,7 +18,7 @@ namespace OCSM.Nodes.CoD.CtL
 		
 		protected override void refreshMetadata()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				var list = ccc.Regalias.Select(r => r.Name)
 					.Union(ccc.Courts.Select(c => c.Name))

--- a/OCSM/scripts/nodes/cod/ctl/options/ContractTypeButton.cs
+++ b/OCSM/scripts/nodes/cod/ctl/options/ContractTypeButton.cs
@@ -1,8 +1,8 @@
 using System.Linq;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Autoload;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes.CoD.CtL
+namespace Ocsm.Nodes.Cofd.Ctl
 {
 	public partial class ContractTypeButton : CustomOption
 	{
@@ -17,7 +17,7 @@ namespace OCSM.Nodes.CoD.CtL
 		
 		protected override void refreshMetadata()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 				replaceItems(ccc.ContractTypes.Select(ct => ct.Name).ToList());
 		}
 	}

--- a/OCSM/scripts/nodes/cod/ctl/options/CourtOptionButton.cs
+++ b/OCSM/scripts/nodes/cod/ctl/options/CourtOptionButton.cs
@@ -1,8 +1,8 @@
 using System.Linq;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Autoload;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes.CoD.CtL
+namespace Ocsm.Nodes.Cofd.Ctl
 {
 	public partial class CourtOptionButton : CustomOption
 	{
@@ -17,7 +17,7 @@ namespace OCSM.Nodes.CoD.CtL
 		
 		protected override void refreshMetadata()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 				replaceItems(ccc.Courts.Select(c => c.Name).ToList());
 		}
 	}

--- a/OCSM/scripts/nodes/cod/ctl/options/KithOptionButton.cs
+++ b/OCSM/scripts/nodes/cod/ctl/options/KithOptionButton.cs
@@ -1,8 +1,8 @@
 using System.Linq;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Autoload;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes.CoD.CtL
+namespace Ocsm.Nodes.Cofd.Ctl
 {
 	public partial class KithOptionButton : CustomOption
 	{
@@ -17,7 +17,7 @@ namespace OCSM.Nodes.CoD.CtL
 		
 		protected override void refreshMetadata()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 				replaceItems(ccc.Kiths.Select(k => k.Name).ToList());
 		}
 	}

--- a/OCSM/scripts/nodes/cod/ctl/options/RegaliaOptionButton.cs
+++ b/OCSM/scripts/nodes/cod/ctl/options/RegaliaOptionButton.cs
@@ -1,8 +1,8 @@
 using System.Linq;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Autoload;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes.CoD.CtL
+namespace Ocsm.Nodes.Cofd.Ctl
 {
 	public partial class RegaliaOptionButton : CustomOption
 	{
@@ -17,7 +17,7 @@ namespace OCSM.Nodes.CoD.CtL
 		
 		protected override void refreshMetadata()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 				replaceItems(ccc.Regalias.Select(r => r.Name).ToList());
 		}
 	}

--- a/OCSM/scripts/nodes/cod/ctl/options/SeemingOptionButton.cs
+++ b/OCSM/scripts/nodes/cod/ctl/options/SeemingOptionButton.cs
@@ -1,8 +1,8 @@
 using System.Linq;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Autoload;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes.CoD.CtL
+namespace Ocsm.Nodes.Cofd.Ctl
 {
 	public partial class SeemingOptionButton : CustomOption
 	{
@@ -17,7 +17,7 @@ namespace OCSM.Nodes.CoD.CtL
 		
 		protected override void refreshMetadata()
 		{
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 				replaceItems(ccc.Seemings.Select(s => s.Name).ToList());
 		}
 	}

--- a/OCSM/scripts/nodes/cod/meta/MeritEntry.cs
+++ b/OCSM/scripts/nodes/cod/meta/MeritEntry.cs
@@ -1,10 +1,10 @@
 using Godot;
 using System;
-using OCSM.CoD;
-using OCSM.CoD.Meta;
-using OCSM.Nodes.Meta;
+using Ocsm.Cofd;
+using Ocsm.Cofd.Meta;
+using Ocsm.Nodes.Meta;
 
-namespace OCSM.Nodes.CoD.Meta
+namespace Ocsm.Nodes.Cofd.Meta
 {
 	public partial class MeritEntry : BasicMetadataEntry, ICanDelete
 	{
@@ -55,7 +55,7 @@ namespace OCSM.Nodes.CoD.Meta
 		{
 			var optionsButton = GetNode<OptionButton>(NodePath.ExistingEntryName);
 			var name = optionsButton.GetItemText((int)index);
-			if(metadataManager.Container is CoDCoreContainer ccc)
+			if(metadataManager.Container is CofdCoreContainer ccc)
 			{
 				if(ccc.Merits.Find(m => m.Name.Equals(name)) is Merit merit)
 				{
@@ -67,7 +67,7 @@ namespace OCSM.Nodes.CoD.Meta
 		
 		public override void refreshMetadata()
 		{
-			if(metadataManager.Container is CoDCoreContainer ccc)
+			if(metadataManager.Container is CofdCoreContainer ccc)
 			{
 				var optionButton = GetNode<OptionButton>(NodePath.ExistingEntryName);
 				optionButton.Clear();

--- a/OCSM/scripts/nodes/cod/sheets/ChangelingSheet.cs
+++ b/OCSM/scripts/nodes/cod/sheets/ChangelingSheet.cs
@@ -2,15 +2,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Godot;
-using OCSM.CoD;
-using OCSM.CoD.CtL;
-using OCSM.CoD.CtL.Meta;
-using OCSM.Nodes.Autoload;
-using OCSM.Nodes.CoD.CtL;
-using OCSM.Nodes.CoD.CtL.Meta;
-using OCSM.Nodes.Sheets;
+using Ocsm.Cofd;
+using Ocsm.Cofd.Ctl;
+using Ocsm.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Autoload;
+using Ocsm.Nodes.Cofd.Ctl;
+using Ocsm.Nodes.Cofd.Ctl.Meta;
+using Ocsm.Nodes.Sheets;
 
-namespace OCSM.Nodes.CoD.Sheets
+namespace Ocsm.Nodes.Cofd.Sheets
 {
 	public partial class ChangelingSheet : CoreSheet<Changeling>, ICharacterSheet
 	{
@@ -64,7 +64,7 @@ namespace OCSM.Nodes.CoD.Sheets
 			Court court = null;
 			Seeming seeming = null;
 			Kith kith = null;
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Courts.Find(c => c.Name.Equals(SheetData.Details.Faction)) is Court c)
 					court = c;
@@ -90,7 +90,7 @@ namespace OCSM.Nodes.CoD.Sheets
 			
 			base._Ready();
 			
-			//Now that CoDCore sets a default maximum on attributes/skills we need to update after base._Ready()
+			//Now that CofdCore sets a default maximum on attributes/skills we need to update after base._Ready()
 			var dotMax = DefaultAttributeMax;
 			if(SheetData.Advantages.Power > 5)
 				dotMax = SheetData.Advantages.Power;
@@ -114,11 +114,11 @@ namespace OCSM.Nodes.CoD.Sheets
 			});
 		}
 		
-		protected void InitContractsList(ContractsList node, List<OCSM.CoD.CtL.Contract> initialValue, ContractsList.ValueChangedEventHandler handler)
+		protected void InitContractsList(ContractsList node, List<Ocsm.Cofd.Ctl.Contract> initialValue, ContractsList.ValueChangedEventHandler handler)
 		{
 			if(node is ContractsList)
 			{
-				if(initialValue is List<OCSM.CoD.CtL.Contract>)
+				if(initialValue is List<Ocsm.Cofd.Ctl.Contract>)
 					node.Values = initialValue;
 				node.refresh();
 				node.ValueChanged += handler;
@@ -167,7 +167,7 @@ namespace OCSM.Nodes.CoD.Sheets
 		
 		private void addExistingMerit(string name)
 		{
-			if(!String.IsNullOrEmpty(name) && metadataManager.Container is CoDChangelingContainer ccc)
+			if(!String.IsNullOrEmpty(name) && metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				if(ccc.Merits.Find(m => m.Name.Equals(name)) is Merit merit)
 				{
@@ -179,12 +179,12 @@ namespace OCSM.Nodes.CoD.Sheets
 		}
 		
 		private void changed_Clarity(long value) { SheetData.Advantages.Integrity = value; }
-		private void changed_Contracts(Transport<List<OCSM.CoD.CtL.Contract>> transport) { SheetData.Contracts = transport.Value; }
+		private void changed_Contracts(Transport<List<Ocsm.Cofd.Ctl.Contract>> transport) { SheetData.Contracts = transport.Value; }
 		
 		private void changed_Court(long index)
 		{
 			var name = String.Empty;
-			if(index > 0 && metadataManager.Container is CoDChangelingContainer ccc && ccc.Courts[(int)index - 1] is Court court)
+			if(index > 0 && metadataManager.Container is CofdChangelingContainer ccc && ccc.Courts[(int)index - 1] is Court court)
 				name = court.Name;
 			
 			SheetData.Details.Faction = name;
@@ -196,7 +196,7 @@ namespace OCSM.Nodes.CoD.Sheets
 		private void changed_Kith(long index)
 		{
 			var name = String.Empty;
-			if(index > 0 && metadataManager.Container is CoDChangelingContainer ccc && ccc.Kiths[(int)index - 1] is Kith kith)
+			if(index > 0 && metadataManager.Container is CofdChangelingContainer ccc && ccc.Kiths[(int)index - 1] is Kith kith)
 				name = kith.Name;
 			
 			SheetData.Details.TypeSecondary = name;
@@ -207,7 +207,7 @@ namespace OCSM.Nodes.CoD.Sheets
 		private void changed_FavoredRegalia(long item)
 		{
 			var pair = new Pair<Regalia, Regalia>();
-			if(metadataManager.Container is CoDChangelingContainer ccc)
+			if(metadataManager.Container is CofdChangelingContainer ccc)
 			{
 				var r1 = regalia1.GetSelectedItemText();
 				var r2 = regalia2.GetSelectedItemText();
@@ -223,7 +223,7 @@ namespace OCSM.Nodes.CoD.Sheets
 		private void changed_Seeming(long index)
 		{
 			var name = String.Empty;
-			if(index > 0 && metadataManager.Container is CoDChangelingContainer ccc && ccc.Seemings[(int)index - 1] is Seeming seeming)
+			if(index > 0 && metadataManager.Container is CofdChangelingContainer ccc && ccc.Seemings[(int)index - 1] is Seeming seeming)
 				name = seeming.Name;
 			
 			SheetData.Details.TypePrimary = name;

--- a/OCSM/scripts/nodes/cod/sheets/CoreSheet.cs
+++ b/OCSM/scripts/nodes/cod/sheets/CoreSheet.cs
@@ -2,10 +2,10 @@ using Godot;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OCSM.CoD;
-using OCSM.Nodes.Sheets;
+using Ocsm.Cofd;
+using Ocsm.Nodes.Sheets;
 
-namespace OCSM.Nodes.CoD.Sheets
+namespace Ocsm.Nodes.Cofd.Sheets
 {
 	public abstract partial class CoreSheet<T> : CharacterSheet<T>
 		where T: CodCore
@@ -135,9 +135,9 @@ namespace OCSM.Nodes.CoD.Sheets
 		protected void updateDefense()
 		{
 			long newValue = 0;
-			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(OCSM.CoD.Attribute.Enum.Dexterity)) is OCSM.CoD.Attribute dex)
+			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(Ocsm.Cofd.Attribute.Enum.Dexterity)) is Ocsm.Cofd.Attribute dex)
 				newValue = dex.Value;
-			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(OCSM.CoD.Attribute.Enum.Wits)) is OCSM.CoD.Attribute wits
+			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(Ocsm.Cofd.Attribute.Enum.Wits)) is Ocsm.Cofd.Attribute wits
 					&& newValue < wits.Value)
 				newValue = wits.Value;
 			if(SheetData.Skills.FirstOrDefault(s => s.Kind.Equals(Skill.Enum.Athletics)) is Skill athl)
@@ -150,9 +150,9 @@ namespace OCSM.Nodes.CoD.Sheets
 		protected void updateInitiative()
 		{
 			long newValue = 0;
-			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(OCSM.CoD.Attribute.Enum.Dexterity)) is OCSM.CoD.Attribute dex)
+			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(Ocsm.Cofd.Attribute.Enum.Dexterity)) is Ocsm.Cofd.Attribute dex)
 				newValue += dex.Value;
-			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(OCSM.CoD.Attribute.Enum.Composure)) is OCSM.CoD.Attribute comp)
+			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(Ocsm.Cofd.Attribute.Enum.Composure)) is Ocsm.Cofd.Attribute comp)
 				newValue += comp.Value;
 			
 			if(newValue > 0)
@@ -161,7 +161,7 @@ namespace OCSM.Nodes.CoD.Sheets
 		
 		protected void updateMaxHealth()
 		{
-			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(OCSM.CoD.Attribute.Enum.Stamina)) is OCSM.CoD.Attribute stam)
+			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(Ocsm.Cofd.Attribute.Enum.Stamina)) is Ocsm.Cofd.Attribute stam)
 			{
 				SheetData.Advantages.Health.Max = SheetData.Advantages.Size + stam.Value;
 				health.updateMax(SheetData.Advantages.Health.Max);
@@ -171,9 +171,9 @@ namespace OCSM.Nodes.CoD.Sheets
 		protected void updateMaxWillpower()
 		{
 			long newValue = 0;
-			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(OCSM.CoD.Attribute.Enum.Composure)) is OCSM.CoD.Attribute comp)
+			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(Ocsm.Cofd.Attribute.Enum.Composure)) is Ocsm.Cofd.Attribute comp)
 				newValue += comp.Value;
-			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(OCSM.CoD.Attribute.Enum.Resolve)) is OCSM.CoD.Attribute res)
+			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(Ocsm.Cofd.Attribute.Enum.Resolve)) is Ocsm.Cofd.Attribute res)
 				newValue += res.Value;
 			
 			if(newValue > 0)
@@ -186,9 +186,9 @@ namespace OCSM.Nodes.CoD.Sheets
 		protected void updateSpeed()
 		{
 			var newValue = SheetData.Advantages.Size;
-			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(OCSM.CoD.Attribute.Enum.Dexterity)) is OCSM.CoD.Attribute dex)
+			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(Ocsm.Cofd.Attribute.Enum.Dexterity)) is Ocsm.Cofd.Attribute dex)
 				newValue += dex.Value;
-			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(OCSM.CoD.Attribute.Enum.Strength)) is OCSM.CoD.Attribute str)
+			if(SheetData.Attributes.FirstOrDefault(a => a.Kind.Equals(Ocsm.Cofd.Attribute.Enum.Strength)) is Ocsm.Cofd.Attribute str)
 				newValue += str.Value;
 			
 			speed.Text = newValue.ToString();
@@ -199,31 +199,31 @@ namespace OCSM.Nodes.CoD.Sheets
 		private void changed_Attribute(TrackSimple node)
 		{
 			var attr = SheetData.Attributes.FirstOrDefault(a => a.Name.Equals(node.Name));
-			if(attr is OCSM.CoD.Attribute)
+			if(attr is Ocsm.Cofd.Attribute)
 			{
 				attr.Value = node.Value;
 				
 				switch(attr.Kind)
 				{
-					case OCSM.CoD.Attribute.Enum.Composure:
+					case Ocsm.Cofd.Attribute.Enum.Composure:
 						updateMaxWillpower();
 						updateInitiative();
 						break;
-					case OCSM.CoD.Attribute.Enum.Dexterity:
+					case Ocsm.Cofd.Attribute.Enum.Dexterity:
 						updateDefense();
 						updateInitiative();
 						updateSpeed();
 						break;
-					case OCSM.CoD.Attribute.Enum.Resolve:
+					case Ocsm.Cofd.Attribute.Enum.Resolve:
 						updateMaxWillpower();
 						break;
-					case OCSM.CoD.Attribute.Enum.Stamina:
+					case Ocsm.Cofd.Attribute.Enum.Stamina:
 						updateMaxHealth();
 						break;
-					case OCSM.CoD.Attribute.Enum.Strength:
+					case Ocsm.Cofd.Attribute.Enum.Strength:
 						updateSpeed();
 						break;
-					case OCSM.CoD.Attribute.Enum.Wits:
+					case Ocsm.Cofd.Attribute.Enum.Wits:
 						updateDefense();
 						break;
 				}

--- a/OCSM/scripts/nodes/cod/sheets/MortalSheet.cs
+++ b/OCSM/scripts/nodes/cod/sheets/MortalSheet.cs
@@ -1,8 +1,8 @@
 using Godot;
-using OCSM.CoD;
-using OCSM.Nodes.Sheets;
+using Ocsm.Cofd;
+using Ocsm.Nodes.Sheets;
 
-namespace OCSM.Nodes.CoD.Sheets
+namespace Ocsm.Nodes.Cofd.Sheets
 {
 	public partial class MortalSheet : CoreSheet<Mortal>, ICharacterSheet
 	{

--- a/OCSM/scripts/nodes/dnd/fifth/AbilityColumn.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/AbilityColumn.cs
@@ -5,7 +5,7 @@ using Ocsm.Dnd.Fifth;
 
 namespace Ocsm.Nodes.Dnd.Fifth
 {
-	public partial class AbilityNode : Container
+	public partial class AbilityColumn : Container
 	{
 		[Signal]
 		public delegate void AbilityChangedEventHandler(Transport<Ability> transport);

--- a/OCSM/scripts/nodes/dnd/fifth/AbilityNode.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/AbilityNode.cs
@@ -1,9 +1,9 @@
 using Godot;
 using System;
 using System.Collections.Generic;
-using OCSM.DnD.Fifth;
+using Ocsm.Dnd.Fifth;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class AbilityNode : Container
 	{
@@ -71,12 +71,12 @@ namespace OCSM.Nodes.DnD.Fifth
 			
 			if(Ability is Ability)
 			{
-				var resource = GD.Load<PackedScene>(Constants.Scene.DnD.Fifth.Skill);
+				var resource = GD.Load<PackedScene>(Constants.Scene.Dnd.Fifth.Skill);
 				Ability.Skills.ForEach(s => instantiateSkill(s, resource));
 			}
 		}
 		
-		private void instantiateSkill(OCSM.DnD.Fifth.Skill skill, PackedScene resource)
+		private void instantiateSkill(Ocsm.Dnd.Fifth.Skill skill, PackedScene resource)
 		{
 			var instance = resource.Instantiate<Skill>();
 			instance.AbilityModifier = Ability.Modifier;
@@ -89,11 +89,11 @@ namespace OCSM.Nodes.DnD.Fifth
 			instance.setProficiency(skill.Proficient);
 		}
 		
-		private void proficiencyChanged(string currentState, OCSM.DnD.Fifth.Skill boundSkill)
+		private void proficiencyChanged(string currentState, Ocsm.Dnd.Fifth.Skill boundSkill)
 		{
 			var proficiency = ProficiencyUtility.fromStatefulButtonState(currentState);
 			boundSkill.Proficient = proficiency;
-			if(Ability.Skills.Find(s => s.Name.Equals(boundSkill.Name)) is OCSM.DnD.Fifth.Skill skill)
+			if(Ability.Skills.Find(s => s.Name.Equals(boundSkill.Name)) is Ocsm.Dnd.Fifth.Skill skill)
 				skill.Proficient = proficiency;
 			EmitSignal(nameof(AbilityChanged), new Transport<Ability>(Ability));
 		}

--- a/OCSM/scripts/nodes/dnd/fifth/AbilityRow.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/AbilityRow.cs
@@ -1,0 +1,114 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+using Ocsm.Dnd.Fifth;
+
+namespace Ocsm.Nodes.Dnd.Fifth
+{
+	public partial class AbilityRow : Container
+	{
+		[Signal]
+		public delegate void AbilityChangedEventHandler(Transport<Ability> transport);
+		
+		private sealed class NodePath
+		{
+			public const string Name = "%Name";
+			public const string Score = "%Score";
+			public const string Modifier = "%Modifier";
+			public const string SavingThrow = "%SavingThrow";
+			public const string Skills = "%Skills";
+		}
+		
+		public Ability Ability { get; set; }
+		public int ProficiencyBonus { get; set; } = 2;
+		
+		private Label name;
+		private SpinBox score;
+		private SpinBox modifier;
+		private Container skillsContainer;
+		private Skill savingThrow;
+		
+		public override void _Ready()
+		{
+			name = GetNode<Label>(NodePath.Name);
+			score = GetNode<SpinBox>(NodePath.Score);
+			modifier = GetNode<SpinBox>(NodePath.Modifier);
+			skillsContainer = GetNode<Container>(NodePath.Skills);
+			savingThrow = GetNode<Skill>(NodePath.SavingThrow);
+			savingThrow.trackAbility(this);
+			savingThrow.ProficiencyChanged += savingThrowChanged;
+			
+			score.ValueChanged += scoreChanged;
+		}
+		
+		public void refresh()
+		{
+			if(Ability is Ability)
+			{
+				name.Text = Ability.Name;
+				score.Value = Ability.Score;
+				modifier.Value = Ability.Modifier;
+				savingThrow.setProficiency(Ability.SavingThrow);
+				renderSkills();
+			}
+		}
+		
+		private void calculateModifier()
+		{
+			modifier.Value = Ability.Modifier;
+			if(modifier.Value >= 0)
+				modifier.Prefix = "+";
+			else
+				modifier.Prefix = String.Empty;
+		}
+		
+		private void renderSkills()
+		{
+			foreach(Node child in skillsContainer.GetChildren())
+			{
+				child.QueueFree();
+			}
+			
+			if(Ability is Ability)
+			{
+				var resource = GD.Load<PackedScene>(Constants.Scene.Dnd.Fifth.Skill);
+				Ability.Skills.ForEach(s => instantiateSkill(s, resource));
+			}
+		}
+		
+		private void instantiateSkill(Ocsm.Dnd.Fifth.Skill skill, PackedScene resource)
+		{
+			var instance = resource.Instantiate<Skill>();
+			instance.AbilityModifier = Ability.Modifier;
+			instance.ProficiencyBonus = ProficiencyBonus;
+			instance.Label = skill.Name;
+			instance.Name = skill.Name;
+			instance.trackAbility(this);
+			instance.ProficiencyChanged += (currentState) => proficiencyChanged(currentState, skill);
+			skillsContainer.AddChild(instance);
+			instance.setProficiency(skill.Proficient);
+		}
+		
+		private void proficiencyChanged(string currentState, Ocsm.Dnd.Fifth.Skill boundSkill)
+		{
+			var proficiency = ProficiencyUtility.fromStatefulButtonState(currentState);
+			boundSkill.Proficient = proficiency;
+			if(Ability.Skills.Find(s => s.Name.Equals(boundSkill.Name)) is Ocsm.Dnd.Fifth.Skill skill)
+				skill.Proficient = proficiency;
+			EmitSignal(nameof(AbilityChanged), new Transport<Ability>(Ability));
+		}
+		
+		private void savingThrowChanged(string currentState)
+		{
+			Ability.SavingThrow = ProficiencyUtility.fromStatefulButtonState(currentState);
+			EmitSignal(nameof(AbilityChanged), new Transport<Ability>(Ability));
+		}
+		
+		private void scoreChanged(double value)
+		{
+			Ability.Score = (int)value;
+			calculateModifier();
+			EmitSignal(nameof(AbilityChanged), new Transport<Ability>(Ability));
+		}
+	}
+}

--- a/OCSM/scripts/nodes/dnd/fifth/AbilityScores.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/AbilityScores.cs
@@ -4,20 +4,44 @@ using Ocsm.Dnd.Fifth;
 
 namespace Ocsm.Nodes.Dnd.Fifth
 {
-	public partial class AbilityScores : HBoxContainer
+	public partial class AbilityScores : Container
 	{
-		private sealed class NodePaths
+		public void initialize<T>(List<Ability> abilities, AbilityColumn.AbilityChangedEventHandler handler)
+			where T: AbilityColumn
 		{
-			public const string Names = "%Names";
-			public const string Scores = "%Scores";
-			public const string SavingThrows = "%SavingThrows";
-			public const string Skills = "%Skills";
+			abilities.ForEach(a => InitAbilityColumn(GetNode<AbilityColumn>("%" + a.Name), a, handler));
 		}
 		
-		public List<Ability> Abilities { get; set; }
-		
-		public override void _Ready()
+		public void initialize<T>(List<Ability> abilities, AbilityRow.AbilityChangedEventHandler handler)
+			where T: AbilityRow
 		{
+			abilities.ForEach(a => InitAbilityRow(GetNode<AbilityRow>("%" + a.Name), a, handler));
+		}
+		
+		protected void InitAbilityColumn(AbilityColumn node, Ability initialValue, AbilityColumn.AbilityChangedEventHandler handler)
+		{
+			if(node is AbilityColumn)
+			{
+				if(initialValue is Ability)
+				{
+					node.Ability = initialValue;
+					node.refresh();
+				}
+				node.AbilityChanged += handler;
+			}
+		}
+		
+		protected void InitAbilityRow(AbilityRow node, Ability initialValue, AbilityRow.AbilityChangedEventHandler handler)
+		{
+			if(node is AbilityRow)
+			{
+				if(initialValue is Ability)
+				{
+					node.Ability = initialValue;
+					node.refresh();
+				}
+				node.AbilityChanged += handler;
+			}
 		}
 	}
 }

--- a/OCSM/scripts/nodes/dnd/fifth/AbilityScores.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/AbilityScores.cs
@@ -1,0 +1,23 @@
+using Godot;
+using System.Collections.Generic;
+using Ocsm.Dnd.Fifth;
+
+namespace Ocsm.Nodes.Dnd.Fifth
+{
+	public partial class AbilityScores : HBoxContainer
+	{
+		private sealed class NodePaths
+		{
+			public const string Names = "%Names";
+			public const string Scores = "%Scores";
+			public const string SavingThrows = "%SavingThrows";
+			public const string Skills = "%Skills";
+		}
+		
+		public List<Ability> Abilities { get; set; }
+		
+		public override void _Ready()
+		{
+		}
+	}
+}

--- a/OCSM/scripts/nodes/dnd/fifth/Feature.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/Feature.cs
@@ -2,7 +2,7 @@ using Godot;
 using System;
 using System.Linq;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class Feature : Container
 	{
@@ -37,7 +37,7 @@ namespace OCSM.Nodes.DnD.Fifth
 			GetNode<TextureButton>(NodePath.ShowHide).Pressed += toggleSections;
 		}
 		
-		public void update(OCSM.DnD.Fifth.Feature feature)
+		public void update(Ocsm.Dnd.Fifth.Feature feature)
 		{
 			var name = feature.Name;
 			if(!String.IsNullOrEmpty(feature.Type))
@@ -54,12 +54,12 @@ namespace OCSM.Nodes.DnD.Fifth
 			
 			if(feature.Sections.Any())
 			{
-				var resource = GD.Load<PackedScene>(Constants.Scene.DnD.Fifth.FeatureSection);
+				var resource = GD.Load<PackedScene>(Constants.Scene.Dnd.Fifth.FeatureSection);
 				feature.Sections.ForEach(s => instantiateSection(s, resource));
 			}
 		}
 		
-		private void instantiateSection(OCSM.DnD.Fifth.FeatureSection section, PackedScene resource)
+		private void instantiateSection(Ocsm.Dnd.Fifth.FeatureSection section, PackedScene resource)
 		{
 			var instance = resource.Instantiate<VBoxContainer>();
 			instance.GetChild<Label>(0).Text = section.Section;

--- a/OCSM/scripts/nodes/dnd/fifth/Inventory.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/Inventory.cs
@@ -1,11 +1,11 @@
 using Godot;
 using System.Collections.Generic;
-using OCSM.DnD.Fifth;
-using OCSM.DnD.Fifth.Inventory;
-using OCSM.DnD.Fifth.Meta;
-using OCSM.Nodes.Autoload;
+using Ocsm.Dnd.Fifth;
+using Ocsm.Dnd.Fifth.Inventory;
+using Ocsm.Dnd.Fifth.Meta;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class Inventory : VBoxContainer
 	{
@@ -46,14 +46,14 @@ namespace OCSM.Nodes.DnD.Fifth
 				c.QueueFree();
 			}
 			
-			var resource = GD.Load<PackedScene>(Constants.Scene.DnD.Fifth.InventoryItem);
+			var resource = GD.Load<PackedScene>(Constants.Scene.Dnd.Fifth.InventoryItem);
 			Items.ForEach(i => instantiateItem(i, resource));
 		}
 		
 		private void addItemHandler()
 		{
 			var metadataManager = GetNode<MetadataManager>(Constants.NodePath.MetadataManager);
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var itemName = options.GetSelectedItemText();
 				if(dfc.AllItems.Find(i => i.Name.Equals(itemName)) is Item item)

--- a/OCSM/scripts/nodes/dnd/fifth/InventoryItem.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/InventoryItem.cs
@@ -2,10 +2,10 @@ using Godot;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using OCSM.DnD.Fifth;
-using OCSM.DnD.Fifth.Inventory;
+using Ocsm.Dnd.Fifth;
+using Ocsm.Dnd.Fifth.Inventory;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class InventoryItem : HBoxContainer
 	{

--- a/OCSM/scripts/nodes/dnd/fifth/Skill.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/Skill.cs
@@ -42,7 +42,12 @@ namespace Ocsm.Nodes.Dnd.Fifth
 			update();
 		}
 		
-		public void trackAbility(AbilityNode ability)
+		public void trackAbility(AbilityColumn ability)
+		{
+			ability.AbilityChanged += scoreChanged;
+		}
+		
+		public void trackAbility(AbilityRow ability)
 		{
 			ability.AbilityChanged += scoreChanged;
 		}

--- a/OCSM/scripts/nodes/dnd/fifth/Skill.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/Skill.cs
@@ -1,8 +1,8 @@
 using Godot;
 using System;
-using OCSM.DnD.Fifth;
+using Ocsm.Dnd.Fifth;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class Skill : Container
 	{

--- a/OCSM/scripts/nodes/dnd/fifth/meta/ArmorEntry.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/meta/ArmorEntry.cs
@@ -1,10 +1,10 @@
 using Godot;
 using System;
-using OCSM.Nodes.Autoload;
-using OCSM.DnD.Fifth.Meta;
-using OCSM.DnD.Fifth.Inventory;
+using Ocsm.Nodes.Autoload;
+using Ocsm.Dnd.Fifth.Meta;
+using Ocsm.Dnd.Fifth.Inventory;
 
-namespace OCSM.Nodes.DnD.Fifth.Meta
+namespace Ocsm.Nodes.Dnd.Fifth.Meta
 {
 	public sealed partial class ArmorEntry : Container, ICanDelete
 	{
@@ -63,7 +63,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		{
 			var optionsButton = GetNode<ArmorOptionsButton>(NodePath.ExistingEntryName);
 			var name = optionsButton.GetItemText((int)index);
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				if(dfc.Armors.Find(a => a.Name.Equals(name)) is ItemArmor armor)
 				{
@@ -95,7 +95,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		public void refreshMetadata()
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var optionButton = GetNode<ArmorOptionsButton>(NodePath.ExistingEntryName);
 				optionButton.Clear();

--- a/OCSM/scripts/nodes/dnd/fifth/meta/BackgroundEntry.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/meta/BackgroundEntry.cs
@@ -1,8 +1,8 @@
 using System;
-using OCSM.DnD.Fifth;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Dnd.Fifth;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.Nodes.DnD.Fifth.Meta
+namespace Ocsm.Nodes.Dnd.Fifth.Meta
 {
 	public partial class BackgroundEntry : FeaturefulMetadataEntry
 	{
@@ -10,7 +10,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		{
 			var optionsButton = GetNode<BackgroundOptionsButton>(NodePath.ExistingEntryName);
 			var name = optionsButton.GetItemText((int)index);
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				if(dfc.Backgrounds.Find(b => b.Name.Equals(name)) is Background background)
 				{
@@ -22,7 +22,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		public override void refreshMetadata()
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var optionButton = GetNode<BackgroundOptionsButton>(NodePath.ExistingEntryName);
 				optionButton.Clear();

--- a/OCSM/scripts/nodes/dnd/fifth/meta/ClassEntry.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/meta/ClassEntry.cs
@@ -1,8 +1,8 @@
 using System;
-using OCSM.DnD.Fifth;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Dnd.Fifth;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.Nodes.DnD.Fifth.Meta
+namespace Ocsm.Nodes.Dnd.Fifth.Meta
 {
 	public partial class ClassEntry : FeaturefulMetadataEntry
 	{
@@ -10,7 +10,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		{
 			var optionsButton = GetNode<ClassOptionsButton>(NodePath.ExistingEntryName);
 			var name = optionsButton.GetItemText((int)index);
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				if(dfc.Classes.Find(c => c.Name.Equals(name)) is Class clazz)
 				{
@@ -22,7 +22,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		public override void refreshMetadata()
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var optionButton = GetNode<ClassOptionsButton>(NodePath.ExistingEntryName);
 				optionButton.Clear();

--- a/OCSM/scripts/nodes/dnd/fifth/meta/DndFifthAddEditMetadata.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/meta/DndFifthAddEditMetadata.cs
@@ -1,12 +1,12 @@
 using Godot;
 using System.Collections.Generic;
-using OCSM.DnD.Fifth;
-using OCSM.DnD.Fifth.Meta;
-using OCSM.DnD.Fifth.Inventory;
-using OCSM.Nodes.Autoload;
-using OCSM.Nodes.Meta;
+using Ocsm.Dnd.Fifth;
+using Ocsm.Dnd.Fifth.Meta;
+using Ocsm.Dnd.Fifth.Inventory;
+using Ocsm.Nodes.Autoload;
+using Ocsm.Nodes.Meta;
 
-namespace OCSM.Nodes.DnD.Fifth.Meta
+namespace Ocsm.Nodes.Dnd.Fifth.Meta
 {
 	public partial class DndFifthAddEditMetadata : BaseAddEditMetadata
 	{
@@ -55,7 +55,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		protected void deleteArmor(string name)
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				if(dfc.Armors.Find(a => a.Name.Equals(name)) is ItemArmor armor)
 				{
@@ -67,7 +67,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		protected void deleteBackground(string name)
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				if(dfc.Backgrounds.Find(b => b.Name.Equals(name)) is Background background)
 				{
@@ -79,7 +79,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		protected void deleteClass(string name)
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				if(dfc.Classes.Find(c => c.Name.Equals(name)) is Class clazz)
 				{
@@ -91,9 +91,9 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		protected void deleteFeature(string name)
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
-				if(dfc.Features.Find(f => f.Name.Equals(name)) is OCSM.DnD.Fifth.Feature feature)
+				if(dfc.Features.Find(f => f.Name.Equals(name)) is Ocsm.Dnd.Fifth.Feature feature)
 				{
 					dfc.Features.Remove(feature);
 					EmitSignal(nameof(MetadataChanged));
@@ -103,7 +103,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		protected void deleteRace(string name)
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				if(dfc.Races.Find(r => r.Name.Equals(name)) is Race race)
 				{
@@ -115,7 +115,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		protected void saveArmor(Transport<ItemArmor> transport)
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var armor = transport.Value;
 				
@@ -128,17 +128,17 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 			}
 		}
 		
-		protected void saveBackground(string name, string description, Transport<List<OCSM.DnD.Fifth.FeatureSection>> sections, Transport<List<OCSM.DnD.Fifth.Feature>> features)
+		protected void saveBackground(string name, string description, Transport<List<Ocsm.Dnd.Fifth.FeatureSection>> sections, Transport<List<Ocsm.Dnd.Fifth.Feature>> features)
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				if(dfc.Backgrounds.Find(b => b.Name.Equals(name)) is Background background)
 					dfc.Backgrounds.Remove(background);
 				
-				var sectionList = new List<OCSM.DnD.Fifth.FeatureSection>();
+				var sectionList = new List<Ocsm.Dnd.Fifth.FeatureSection>();
 				sections.Value.ForEach(fs => sectionList.Add(fs));
 				
-				var featureList = new List<OCSM.DnD.Fifth.Feature>();
+				var featureList = new List<Ocsm.Dnd.Fifth.Feature>();
 				features.Value.ForEach(f => featureList.Add(f));
 				
 				dfc.Backgrounds.Add(new Background() { Description = description, Features = featureList, Name = name, Sections = sectionList, });
@@ -147,30 +147,30 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 			}
 		}
 		
-		protected void saveClass(string name, string description, Transport<List<OCSM.DnD.Fifth.FeatureSection>> sections, Transport<List<OCSM.DnD.Fifth.Feature>> features)
+		protected void saveClass(string name, string description, Transport<List<Ocsm.Dnd.Fifth.FeatureSection>> sections, Transport<List<Ocsm.Dnd.Fifth.Feature>> features)
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				if(dfc.Classes.Find(c => c.Name.Equals(name)) is Class clazz)
 					dfc.Classes.Remove(clazz);
 				
-				var sectionList = new List<OCSM.DnD.Fifth.FeatureSection>();
+				var sectionList = new List<Ocsm.Dnd.Fifth.FeatureSection>();
 				sections.Value.ForEach(fs => sectionList.Add(fs));
 				
-				var featureList = new List<OCSM.DnD.Fifth.Feature>();
+				var featureList = new List<Ocsm.Dnd.Fifth.Feature>();
 				features.Value.ForEach(f => featureList.Add(f));
 				
-				dfc.Classes.Add(new Class() { Description = description, Features = featureList, HitDie = OCSM.DnD.Fifth.Die.d10, Name = name, Sections = sectionList, });
+				dfc.Classes.Add(new Class() { Description = description, Features = featureList, HitDie = Ocsm.Dnd.Fifth.Die.d10, Name = name, Sections = sectionList, });
 				dfc.Classes.Sort();
 				EmitSignal(nameof(MetadataChanged));
 			}
 		}
 		
-		protected void saveFeature(Transport<OCSM.DnD.Fifth.Feature> transport)
+		protected void saveFeature(Transport<Ocsm.Dnd.Fifth.Feature> transport)
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
-				if(dfc.Features.Find(f => f.Name.Equals(transport.Value.Name)) is OCSM.DnD.Fifth.Feature feature)
+				if(dfc.Features.Find(f => f.Name.Equals(transport.Value.Name)) is Ocsm.Dnd.Fifth.Feature feature)
 					dfc.Features.Remove(feature);
 				
 				dfc.Features.Add(transport.Value);
@@ -179,17 +179,17 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 			}
 		}
 		
-		protected void saveRace(string name, string description, Transport<List<OCSM.DnD.Fifth.FeatureSection>> sections, Transport<List<OCSM.DnD.Fifth.Feature>> features)
+		protected void saveRace(string name, string description, Transport<List<Ocsm.Dnd.Fifth.FeatureSection>> sections, Transport<List<Ocsm.Dnd.Fifth.Feature>> features)
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				if(dfc.Races.Find(r => r.Name.Equals(name)) is Race race)
 					dfc.Races.Remove(race);
 				
-				var sectionList = new List<OCSM.DnD.Fifth.FeatureSection>();
+				var sectionList = new List<Ocsm.Dnd.Fifth.FeatureSection>();
 				sections.Value.ForEach(fs => sectionList.Add(fs));
 				
-				var featureList = new List<OCSM.DnD.Fifth.Feature>();
+				var featureList = new List<Ocsm.Dnd.Fifth.Feature>();
 				features.Value.ForEach(f => featureList.Add(f));
 				
 				dfc.Races.Add(new Race() { Description = description, Features = featureList, Name = name, Sections = sectionList, });

--- a/OCSM/scripts/nodes/dnd/fifth/meta/FeatureEntry.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/meta/FeatureEntry.cs
@@ -1,11 +1,11 @@
 using Godot;
 using System.Linq;
 using System.Collections.Generic;
-using OCSM.DnD.Fifth;
-using OCSM.DnD.Fifth.Meta;
-using OCSM.Nodes.Autoload;
+using Ocsm.Dnd.Fifth;
+using Ocsm.Dnd.Fifth.Meta;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes.DnD.Fifth.Meta
+namespace Ocsm.Nodes.Dnd.Fifth.Meta
 {
 	public partial class FeatureEntry : Container, ICanDelete
 	{
@@ -32,11 +32,11 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		public const string ExistingLabelFormat = "Existing {0}";
 		
 		[Signal]
-		public delegate void SaveClickedEventHandler(Transport<OCSM.DnD.Fifth.Feature> feature);
+		public delegate void SaveClickedEventHandler(Transport<Ocsm.Dnd.Fifth.Feature> feature);
 		[Signal]
 		public delegate void DeleteConfirmedEventHandler(string name);
 		
-		public OCSM.DnD.Fifth.Feature Feature { get; set; }
+		public Ocsm.Dnd.Fifth.Feature Feature { get; set; }
 		
 		private Label classLabel;
 		private ClassOptionsButton classNode;
@@ -55,8 +55,8 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		{
 			metadataManager = GetNode<MetadataManager>(Constants.NodePath.MetadataManager);
 			
-			if(!(Feature is OCSM.DnD.Fifth.Feature))
-				Feature = new OCSM.DnD.Fifth.Feature();
+			if(!(Feature is Ocsm.Dnd.Fifth.Feature))
+				Feature = new Ocsm.Dnd.Fifth.Feature();
 			
 			classLabel = GetNode<Label>(NodePath.ClassLabel);
 			classNode = GetNode<ClassOptionsButton>(NodePath.Class);
@@ -89,7 +89,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		private void refreshValues()
 		{
-			if(Feature is OCSM.DnD.Fifth.Feature)
+			if(Feature is Ocsm.Dnd.Fifth.Feature)
 			{
 				classNode.select(Feature.ClassName);
 				descriptionNode.Text = Feature.Description;
@@ -109,13 +109,13 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		private void clearInputs()
 		{
-			Feature = new OCSM.DnD.Fifth.Feature();
+			Feature = new Ocsm.Dnd.Fifth.Feature();
 			refreshValues();
 		}
 		
 		private void doSave()
 		{
-			EmitSignal(nameof(SaveClicked), new Transport<OCSM.DnD.Fifth.Feature>(Feature));
+			EmitSignal(nameof(SaveClicked), new Transport<Ocsm.Dnd.Fifth.Feature>(Feature));
 			clearInputs();
 		}
 		
@@ -140,9 +140,9 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		{
 			var optionsButton = GetNode<FeatureOptionsButton>(NodePath.ExistingEntryName);
 			var name = optionsButton.GetItemText((int)index);
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
-				if(dfc.Features.Find(f => f.Name.Equals(name)) is OCSM.DnD.Fifth.Feature feature)
+				if(dfc.Features.Find(f => f.Name.Equals(name)) is Ocsm.Dnd.Fifth.Feature feature)
 				{
 					loadEntry(feature);
 					optionsButton.Deselect();
@@ -150,9 +150,9 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 			}
 		}
 		
-		public void loadEntry(OCSM.DnD.Fifth.Feature feature)
+		public void loadEntry(Ocsm.Dnd.Fifth.Feature feature)
 		{
-			if(feature is OCSM.DnD.Fifth.Feature)
+			if(feature is Ocsm.Dnd.Fifth.Feature)
 			{
 				Feature = feature;
 				Feature.NumericBonuses.Sort();

--- a/OCSM/scripts/nodes/dnd/fifth/meta/FeaturefulMetadataEntry.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/meta/FeaturefulMetadataEntry.cs
@@ -1,9 +1,9 @@
 using Godot;
 using System.Collections.Generic;
-using OCSM.Nodes.Meta;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Nodes.Meta;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.Nodes.DnD.Fifth.Meta
+namespace Ocsm.Nodes.Dnd.Fifth.Meta
 {
 	public partial class FeaturefulMetadataEntry : BasicMetadataEntry
 	{
@@ -15,15 +15,15 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		}
 		
 		[Signal]
-		public new delegate void SaveClickedEventHandler(string name, string description, Transport<List<OCSM.DnD.Fifth.FeatureSection>> sections, Transport<List<OCSM.DnD.Fifth.Feature>> features);
+		public new delegate void SaveClickedEventHandler(string name, string description, Transport<List<Ocsm.Dnd.Fifth.FeatureSection>> sections, Transport<List<Ocsm.Dnd.Fifth.Feature>> features);
 		
-		protected List<OCSM.DnD.Fifth.Feature> Features;
+		protected List<Ocsm.Dnd.Fifth.Feature> Features;
 		
 		protected Container featureContainer;
 		
 		public new void _Ready()
 		{
-			Features = new List<OCSM.DnD.Fifth.Feature>();
+			Features = new List<Ocsm.Dnd.Fifth.Feature>();
 			
 			featureContainer = GetNode<Container>(NodePath.FeaturesName);
 			
@@ -38,24 +38,24 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 				c.QueueFree();
 			}
 			
-			var resource = GD.Load<PackedScene>(Constants.Scene.DnD.Fifth.Feature);
+			var resource = GD.Load<PackedScene>(Constants.Scene.Dnd.Fifth.Feature);
 			Features.ForEach(f => instantiateFeature(f, resource));
 		}
 		
-		protected void instantiateFeature(OCSM.DnD.Fifth.Feature feature, PackedScene resource)
+		protected void instantiateFeature(Ocsm.Dnd.Fifth.Feature feature, PackedScene resource)
 		{
 			var instance = resource.Instantiate<Feature>();
 			var button = new Button();
 			button.Text = "Remove";
 			button.SizeFlagsHorizontal = Control.SizeFlags.ShrinkCenter;
-			button.Pressed += () => removeFeature(new Transport<OCSM.DnD.Fifth.Feature>(feature));
+			button.Pressed += () => removeFeature(new Transport<Ocsm.Dnd.Fifth.Feature>(feature));
 			instance.AddChild(button);
 			featureContainer.AddChild(instance);
 			
 			instance.update(feature);
 		}
 		
-		protected void removeFeature(Transport<OCSM.DnD.Fifth.Feature> transport)
+		protected void removeFeature(Transport<Ocsm.Dnd.Fifth.Feature> transport)
 		{
 			Features.Remove(transport.Value);
 			renderFeatures();
@@ -65,9 +65,9 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		{
 			base.clearInputs();
 			var sections = GetNode<SectionList>(NodePath.SectionsName);
-			sections.Values = new List<OCSM.DnD.Fifth.FeatureSection>();
+			sections.Values = new List<Ocsm.Dnd.Fifth.FeatureSection>();
 			sections.refresh();
-			Features = new List<OCSM.DnD.Fifth.Feature>();
+			Features = new List<Ocsm.Dnd.Fifth.Feature>();
 			renderFeatures();
 		}
 		
@@ -77,17 +77,17 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 			var description = GetNode<TextEdit>(NodePath.DescriptionInput).Text;
 			var sections = GetNode<SectionList>(NodePath.SectionsName).Values;
 			
-			EmitSignal(nameof(SaveClicked), name, description, new Transport<List<OCSM.DnD.Fifth.FeatureSection>>(sections), new Transport<List<OCSM.DnD.Fifth.Feature>>(Features));
+			EmitSignal(nameof(SaveClicked), name, description, new Transport<List<Ocsm.Dnd.Fifth.FeatureSection>>(sections), new Transport<List<Ocsm.Dnd.Fifth.Feature>>(Features));
 			clearInputs();
 		}
 		
 		private void featureSelected(long index)
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var optionsButton = GetNode<FeatureOptionsButton>(NodePath.ExistingFeaturesName);
 				var name = optionsButton.GetItemText((int)index);
-				if(dfc.Features.Find(f => f.Name.Equals(name)) is OCSM.DnD.Fifth.Feature feature && !Features.Contains(feature))
+				if(dfc.Features.Find(f => f.Name.Equals(name)) is Ocsm.Dnd.Fifth.Feature feature && !Features.Contains(feature))
 				{
 					Features.Add(feature);
 					Features.Sort();

--- a/OCSM/scripts/nodes/dnd/fifth/meta/NumericBonusEdit.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/meta/NumericBonusEdit.cs
@@ -1,8 +1,8 @@
 using Godot;
 using System;
-using OCSM.DnD.Fifth;
+using Ocsm.Dnd.Fifth;
 
-namespace OCSM.Nodes.DnD.Fifth.Meta
+namespace Ocsm.Nodes.Dnd.Fifth.Meta
 {
 	public partial class NumericBonusEdit : Container
 	{

--- a/OCSM/scripts/nodes/dnd/fifth/meta/NumericBonusEditList.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/meta/NumericBonusEditList.cs
@@ -2,9 +2,9 @@ using Godot;
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using OCSM.DnD.Fifth;
+using Ocsm.Dnd.Fifth;
 
-namespace OCSM.Nodes.DnD.Fifth.Meta
+namespace Ocsm.Nodes.Dnd.Fifth.Meta
 {
 	public partial class NumericBonusEditList : Container
 	{
@@ -57,7 +57,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		private void addInput(NumericBonus bonus = null)
 		{
-			var resource = GD.Load<PackedScene>(Constants.Scene.DnD.Fifth.Meta.NumericBonusEdit);
+			var resource = GD.Load<PackedScene>(Constants.Scene.Dnd.Fifth.Meta.NumericBonusEdit);
 			var instance = resource.Instantiate<NumericBonusEdit>();
 			
 			AddChild(instance);

--- a/OCSM/scripts/nodes/dnd/fifth/meta/RaceEntry.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/meta/RaceEntry.cs
@@ -1,8 +1,8 @@
 using System;
-using OCSM.DnD.Fifth;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Dnd.Fifth;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.Nodes.DnD.Fifth.Meta
+namespace Ocsm.Nodes.Dnd.Fifth.Meta
 {
 	public partial class RaceEntry : FeaturefulMetadataEntry
 	{
@@ -10,7 +10,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		{
 			var optionsButton = GetNode<RaceOptionsButton>(NodePath.ExistingEntryName);
 			var name = optionsButton.GetItemText((int)index);
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				if(dfc.Races.Find(r => r.Name.Equals(name)) is Race race)
 				{
@@ -22,7 +22,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		public override void refreshMetadata()
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var optionButton = GetNode<RaceOptionsButton>(NodePath.ExistingEntryName);
 				optionButton.Clear();

--- a/OCSM/scripts/nodes/dnd/fifth/meta/SectionList.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/meta/SectionList.cs
@@ -2,9 +2,9 @@ using Godot;
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using OCSM.DnD.Fifth;
+using Ocsm.Dnd.Fifth;
 
-namespace OCSM.Nodes.DnD.Fifth.Meta
+namespace Ocsm.Nodes.Dnd.Fifth.Meta
 {
 	public partial class SectionList : Container
 	{
@@ -61,7 +61,7 @@ namespace OCSM.Nodes.DnD.Fifth.Meta
 		
 		private void addInput(FeatureSection section = null)
 		{
-			var resource = GD.Load<PackedScene>(Constants.Scene.DnD.Fifth.Meta.FeatureSectionEntry);
+			var resource = GD.Load<PackedScene>(Constants.Scene.Dnd.Fifth.Meta.FeatureSectionEntry);
 			var instance = resource.Instantiate<HBoxContainer>();
 			
 			AddChild(instance);

--- a/OCSM/scripts/nodes/dnd/fifth/options/AbilityOptionsButton.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/AbilityOptionsButton.cs
@@ -1,7 +1,7 @@
 using System;
-using OCSM.DnD.Fifth;
+using Ocsm.Dnd.Fifth;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class AbilityOptionsButton : CustomOption
 	{

--- a/OCSM/scripts/nodes/dnd/fifth/options/ArmorOptionsButton.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/ArmorOptionsButton.cs
@@ -1,13 +1,13 @@
 using System;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class ArmorOptionsButton : CustomOption
 	{
 		protected override void refreshMetadata()
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var index = Selected;
 				

--- a/OCSM/scripts/nodes/dnd/fifth/options/ArmorTypeOptions.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/ArmorTypeOptions.cs
@@ -1,8 +1,8 @@
 using System;
 using Godot;
-using OCSM.DnD.Fifth.Inventory;
+using Ocsm.Dnd.Fifth.Inventory;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class ArmorTypeOptions : OptionButton
 	{

--- a/OCSM/scripts/nodes/dnd/fifth/options/BackgroundOptionsButton.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/BackgroundOptionsButton.cs
@@ -1,13 +1,13 @@
 using System;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class BackgroundOptionsButton : CustomOption
 	{
 		protected override void refreshMetadata()
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var index = Selected;
 				

--- a/OCSM/scripts/nodes/dnd/fifth/options/ClassOptionsButton.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/ClassOptionsButton.cs
@@ -1,13 +1,13 @@
 using System;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class ClassOptionsButton : CustomOption
 	{
 		protected override void refreshMetadata()
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var index = Selected;
 				

--- a/OCSM/scripts/nodes/dnd/fifth/options/DieOptionsButton.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/DieOptionsButton.cs
@@ -1,7 +1,7 @@
 using Godot;
 using System;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class DieOptionsButton : CustomOption
 	{
@@ -15,17 +15,17 @@ namespace OCSM.Nodes.DnD.Fifth
 			AddItem(String.Empty);
 			
 			if(!BardicInspiration)
-				AddItem(OCSM.DnD.Fifth.Die.d4.ToString());
+				AddItem(Ocsm.Dnd.Fifth.Die.d4.ToString());
 			
-			AddItem(OCSM.DnD.Fifth.Die.d6.ToString());
-			AddItem(OCSM.DnD.Fifth.Die.d8.ToString());
-			AddItem(OCSM.DnD.Fifth.Die.d10.ToString());
-			AddItem(OCSM.DnD.Fifth.Die.d12.ToString());
+			AddItem(Ocsm.Dnd.Fifth.Die.d6.ToString());
+			AddItem(Ocsm.Dnd.Fifth.Die.d8.ToString());
+			AddItem(Ocsm.Dnd.Fifth.Die.d10.ToString());
+			AddItem(Ocsm.Dnd.Fifth.Die.d12.ToString());
 			
 			if(!BardicInspiration && !DamageDie)
 			{
-				AddItem(OCSM.DnD.Fifth.Die.d20.ToString());
-				AddItem(OCSM.DnD.Fifth.Die.d100.ToString());
+				AddItem(Ocsm.Dnd.Fifth.Die.d20.ToString());
+				AddItem(Ocsm.Dnd.Fifth.Die.d100.ToString());
 			}
 		}
 	}

--- a/OCSM/scripts/nodes/dnd/fifth/options/FeatureOptionsButton.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/FeatureOptionsButton.cs
@@ -1,13 +1,13 @@
 using System;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class FeatureOptionsButton : CustomOption
 	{
 		protected override void refreshMetadata()
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var index = Selected;
 				

--- a/OCSM/scripts/nodes/dnd/fifth/options/FeatureTypeOptionsButton.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/FeatureTypeOptionsButton.cs
@@ -1,8 +1,8 @@
 using Godot;
 using System;
-using OCSM.DnD.Fifth;
+using Ocsm.Dnd.Fifth;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class FeatureTypeOptionsButton : CustomOption
 	{

--- a/OCSM/scripts/nodes/dnd/fifth/options/InventoryItemOptions.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/InventoryItemOptions.cs
@@ -1,13 +1,13 @@
 using System;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class InventoryItemOptions : CustomOption
 	{
 		protected override void refreshMetadata()
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var index = Selected;
 				

--- a/OCSM/scripts/nodes/dnd/fifth/options/NumericStatOptionsButton.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/NumericStatOptionsButton.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Linq;
-using OCSM.DnD.Fifth;
+using Ocsm.Dnd.Fifth;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class NumericStatOptionsButton : CustomOption
 	{

--- a/OCSM/scripts/nodes/dnd/fifth/options/RaceOptionsButton.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/RaceOptionsButton.cs
@@ -1,13 +1,13 @@
 using System;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class RaceOptionsButton : CustomOption
 	{
 		protected override void refreshMetadata()
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var index = Selected;
 				

--- a/OCSM/scripts/nodes/dnd/fifth/options/WeaponOptions.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/WeaponOptions.cs
@@ -1,13 +1,13 @@
 using System;
-using OCSM.DnD.Fifth.Meta;
+using Ocsm.Dnd.Fifth.Meta;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class WeaponOptions : CustomOption
 	{
 		protected override void refreshMetadata()
 		{
-			if(metadataManager.Container is DnDFifthContainer dfc)
+			if(metadataManager.Container is DndFifthContainer dfc)
 			{
 				var index = Selected;
 				

--- a/OCSM/scripts/nodes/dnd/fifth/options/WeaponPropertyOptions.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/WeaponPropertyOptions.cs
@@ -1,8 +1,8 @@
 using System;
 using Godot;
-using OCSM.DnD.Fifth.Inventory;
+using Ocsm.Dnd.Fifth.Inventory;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class WeaponPropertyOptions : OptionButton
 	{

--- a/OCSM/scripts/nodes/dnd/fifth/options/WeaponTypeOptions.cs
+++ b/OCSM/scripts/nodes/dnd/fifth/options/WeaponTypeOptions.cs
@@ -1,8 +1,8 @@
 using System;
 using Godot;
-using OCSM.DnD.Fifth.Inventory;
+using Ocsm.Dnd.Fifth.Inventory;
 
-namespace OCSM.Nodes.DnD.Fifth
+namespace Ocsm.Nodes.Dnd.Fifth
 {
 	public partial class WeaponTypeOptions : OptionButton
 	{

--- a/OCSM/scripts/nodes/dnd/sheets/DndFifthSheet.cs
+++ b/OCSM/scripts/nodes/dnd/sheets/DndFifthSheet.cs
@@ -13,8 +13,9 @@ namespace Ocsm.Nodes.Dnd.Sheets
 {
 	public partial class DndFifthSheet : CharacterSheet<FifthAdventurer>
 	{
-		private sealed class NodePath
+		private sealed class NodePaths
 		{
+			public const string AbilityScores = "%Ability Scores";
 			public const string Alignment = "%Alignment";
 			public const string ArmorClass = "%ArmorClass";
 			public const string Background = "%Background";
@@ -65,36 +66,36 @@ namespace Ocsm.Nodes.Dnd.Sheets
 			if(!(SheetData is FifthAdventurer))
 				SheetData = new FifthAdventurer();
 			
-			inventory = GetNode<Inventory>(NodePath.Inventory);
-			bardicInspirationDie = GetNode<DieOptionsButton>(NodePath.BardicInspirationDie);
-			bonds = GetNode<TextEdit>(NodePath.Bonds);
-			flaws = GetNode<TextEdit>(NodePath.Flaws);
-			ideals = GetNode<TextEdit>(NodePath.Ideals);
-			personalityTraits = GetNode<TextEdit>(NodePath.PersonalityTraits);
-			backgroundFeatures = GetNode<VBoxContainer>(NodePath.BackgroundFeatures);
-			raceFeatures = GetNode<VBoxContainer>(NodePath.RaceFeatures);
-			armorClass = GetNode<SpinBox>(NodePath.ArmorClass);
-			initiativeBonus = GetNode<SpinBox>(NodePath.InitiativeBonus);
-			speed = GetNode<SpinBox>(NodePath.Speed);
+			inventory = GetNode<Inventory>(NodePaths.Inventory);
+			bardicInspirationDie = GetNode<DieOptionsButton>(NodePaths.BardicInspirationDie);
+			bonds = GetNode<TextEdit>(NodePaths.Bonds);
+			flaws = GetNode<TextEdit>(NodePaths.Flaws);
+			ideals = GetNode<TextEdit>(NodePaths.Ideals);
+			personalityTraits = GetNode<TextEdit>(NodePaths.PersonalityTraits);
+			backgroundFeatures = GetNode<VBoxContainer>(NodePaths.BackgroundFeatures);
+			raceFeatures = GetNode<VBoxContainer>(NodePaths.RaceFeatures);
+			armorClass = GetNode<SpinBox>(NodePaths.ArmorClass);
+			initiativeBonus = GetNode<SpinBox>(NodePaths.InitiativeBonus);
+			speed = GetNode<SpinBox>(NodePaths.Speed);
 			
-			InitLineEdit(GetNode<LineEdit>(NodePath.CharacterName), SheetData.Name, changed_CharacterName);
-			InitLineEdit(GetNode<LineEdit>(NodePath.PlayerName), SheetData.Player, changed_PlayerName);
-			InitLineEdit(GetNode<LineEdit>(NodePath.Alignment), SheetData.Alignment, changed_Alignment);
-			InitRaceOptionsButton(GetNode<RaceOptionsButton>(NodePath.Race), SheetData.Race, changed_Race);
-			InitBackgroundOptionsButton(GetNode<BackgroundOptionsButton>(NodePath.Background), SheetData.Background, changed_Background);
+			InitLineEdit(GetNode<LineEdit>(NodePaths.CharacterName), SheetData.Name, changed_CharacterName);
+			InitLineEdit(GetNode<LineEdit>(NodePaths.PlayerName), SheetData.Player, changed_PlayerName);
+			InitLineEdit(GetNode<LineEdit>(NodePaths.Alignment), SheetData.Alignment, changed_Alignment);
+			InitRaceOptionsButton(GetNode<RaceOptionsButton>(NodePaths.Race), SheetData.Race, changed_Race);
+			InitBackgroundOptionsButton(GetNode<BackgroundOptionsButton>(NodePaths.Background), SheetData.Background, changed_Background);
 			
-			InitSpinBox(GetNode<SpinBox>(NodePath.CurrentHP), SheetData.HP.Current, changed_CurrentHP);
-			InitSpinBox(GetNode<SpinBox>(NodePath.MaxHP), SheetData.HP.Max, changed_MaxHP);
-			InitSpinBox(GetNode<SpinBox>(NodePath.TempHP), SheetData.HP.Temp, changed_TempHP);
+			InitSpinBox(GetNode<SpinBox>(NodePaths.CurrentHP), SheetData.HP.Current, changed_CurrentHP);
+			InitSpinBox(GetNode<SpinBox>(NodePaths.MaxHP), SheetData.HP.Max, changed_MaxHP);
+			InitSpinBox(GetNode<SpinBox>(NodePaths.TempHP), SheetData.HP.Temp, changed_TempHP);
 			
-			InitSpinBox(GetNode<SpinBox>(NodePath.Copper), SheetData.CoinPurse.Copper, changed_Copper);
-			InitSpinBox(GetNode<SpinBox>(NodePath.Silver), SheetData.CoinPurse.Silver, changed_Silver);
-			InitSpinBox(GetNode<SpinBox>(NodePath.Electrum), SheetData.CoinPurse.Electrum, changed_Electrum);
-			InitSpinBox(GetNode<SpinBox>(NodePath.Gold), SheetData.CoinPurse.Gold, changed_Gold);
-			InitSpinBox(GetNode<SpinBox>(NodePath.Platinum), SheetData.CoinPurse.Platinum, changed_Platinum);
+			InitSpinBox(GetNode<SpinBox>(NodePaths.Copper), SheetData.CoinPurse.Copper, changed_Copper);
+			InitSpinBox(GetNode<SpinBox>(NodePaths.Silver), SheetData.CoinPurse.Silver, changed_Silver);
+			InitSpinBox(GetNode<SpinBox>(NodePaths.Electrum), SheetData.CoinPurse.Electrum, changed_Electrum);
+			InitSpinBox(GetNode<SpinBox>(NodePaths.Gold), SheetData.CoinPurse.Gold, changed_Gold);
+			InitSpinBox(GetNode<SpinBox>(NodePaths.Platinum), SheetData.CoinPurse.Platinum, changed_Platinum);
 			
-			InitToggleButton(GetNode<ToggleButton>(NodePath.Inspiration), SheetData.Inspiration, changed_Inspiration);
-			InitToggleButton(GetNode<ToggleButton>(NodePath.BardicInspiration), SheetData.BardicInspiration, changed_BardicInspiration);
+			InitToggleButton(GetNode<ToggleButton>(NodePaths.Inspiration), SheetData.Inspiration, changed_Inspiration);
+			InitToggleButton(GetNode<ToggleButton>(NodePaths.BardicInspiration), SheetData.BardicInspiration, changed_BardicInspiration);
 			InitDieOptionsButton(bardicInspirationDie, SheetData.BardicInspirationDie, changed_BardicInspirationDie);
 			
 			InitTextEdit(personalityTraits, SheetData.PersonalityTraits, changed_PersonalityTraits);
@@ -102,7 +103,8 @@ namespace Ocsm.Nodes.Dnd.Sheets
 			InitTextEdit(bonds, SheetData.Bonds, changed_Bonds);
 			InitTextEdit(flaws, SheetData.Flaws, changed_Flaws);
 			
-			SheetData.Abilities.ForEach(a => InitAbilityNode(GetNode<AbilityNode>("%" + a.Name), a, changed_Ability));
+			GetNode<AbilityScores>(NodePaths.AbilityScores)
+				.initialize<AbilityRow>(SheetData.Abilities, changed_Ability);
 			
 			InitInventory(inventory, SheetData.Inventory, changed_Inventory);
 			
@@ -110,19 +112,6 @@ namespace Ocsm.Nodes.Dnd.Sheets
 			refreshFeatures();
 			toggleBardicInspirationDie();
 			updateCalculatedTraits();
-		}
-		
-		protected void InitAbilityNode(AbilityNode node, Ability initialValue, AbilityNode.AbilityChangedEventHandler handler)
-		{
-			if(node is AbilityNode)
-			{
-				if(initialValue is Ability)
-				{
-					node.Ability = initialValue;
-					node.refresh();
-				}
-				node.AbilityChanged += handler;
-			}
 		}
 		
 		protected void InitBackgroundOptionsButton(BackgroundOptionsButton node, Background initialValue, BackgroundOptionsButton.ItemSelectedEventHandler handler)

--- a/OCSM/scripts/nodes/dnd/sheets/DndFifthSheet.cs
+++ b/OCSM/scripts/nodes/dnd/sheets/DndFifthSheet.cs
@@ -2,14 +2,14 @@ using Godot;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OCSM.DnD.Fifth;
-using OCSM.Nodes.Autoload;
-using OCSM.Nodes.DnD.Fifth;
-using OCSM.Nodes.Sheets;
-using OCSM.DnD.Fifth.Meta;
-using OCSM.DnD.Fifth.Inventory;
+using Ocsm.Dnd.Fifth;
+using Ocsm.Nodes.Autoload;
+using Ocsm.Nodes.Dnd.Fifth;
+using Ocsm.Nodes.Sheets;
+using Ocsm.Dnd.Fifth.Meta;
+using Ocsm.Dnd.Fifth.Inventory;
 
-namespace OCSM.Nodes.DnD.Sheets
+namespace Ocsm.Nodes.Dnd.Sheets
 {
 	public partial class DndFifthSheet : CharacterSheet<FifthAdventurer>
 	{
@@ -145,11 +145,11 @@ namespace OCSM.Nodes.DnD.Sheets
 			}
 		}
 		
-		protected void InitDieOptionsButton(DieOptionsButton node, OCSM.DnD.Fifth.Die initialValue, DieOptionsButton.ItemSelectedEventHandler handler)
+		protected void InitDieOptionsButton(DieOptionsButton node, Ocsm.Dnd.Fifth.Die initialValue, DieOptionsButton.ItemSelectedEventHandler handler)
 		{
 			if(node is DieOptionsButton)
 			{
-				if(initialValue is OCSM.DnD.Fifth.Die)
+				if(initialValue is Ocsm.Dnd.Fifth.Die)
 					node.SelectItemByText(initialValue.ToString());
 				node.ItemSelected += handler;
 			}
@@ -169,7 +169,7 @@ namespace OCSM.Nodes.DnD.Sheets
 				//validate each item before adding
 				
 				/*
-				if(metadataManager.Container is DnDFifthContainer dfc)
+				if(metadataManager.Container is DndFifthContainer dfc)
 					dfc.Items.Where(item => items.Find(i => i.Name.Equals(item.Name)).Any())
 						.ToList()
 						.ForEach(item => node.Items.Add(item));
@@ -294,7 +294,7 @@ namespace OCSM.Nodes.DnD.Sheets
 		
 		private void changed_Background(long index)
 		{
-			if(index > 0 && metadataManager.Container is DnDFifthContainer dfc && dfc.Backgrounds[(int)index - 1] is Background background)
+			if(index > 0 && metadataManager.Container is DndFifthContainer dfc && dfc.Backgrounds[(int)index - 1] is Background background)
 				SheetData.Background = background;
 			else
 				SheetData.Background = null;
@@ -313,7 +313,7 @@ namespace OCSM.Nodes.DnD.Sheets
 			var text = bardicInspirationDie.GetItemText((int)index);
 			if(!String.IsNullOrEmpty(text))
 			{
-				var die = new OCSM.DnD.Fifth.Die() { Sides = int.Parse(text.Substring(1)) };
+				var die = new Ocsm.Dnd.Fifth.Die() { Sides = int.Parse(text.Substring(1)) };
 				SheetData.BardicInspirationDie = die;
 			}
 			else
@@ -354,7 +354,7 @@ namespace OCSM.Nodes.DnD.Sheets
 		
 		private void changed_Race(long index)
 		{
-			if(index > 0 && metadataManager.Container is DnDFifthContainer dfc && dfc.Races[(int)index - 1] is Race race)
+			if(index > 0 && metadataManager.Container is DndFifthContainer dfc && dfc.Races[(int)index - 1] is Race race)
 				SheetData.Race = race;
 			else
 				SheetData.Race = null;
@@ -365,9 +365,9 @@ namespace OCSM.Nodes.DnD.Sheets
 		private void changed_Silver(double value) { SheetData.CoinPurse.Silver = (int)value; }
 		private void changed_TempHP(double value) { SheetData.HP.Temp = (int)value; }
 		
-		private List<OCSM.DnD.Fifth.Feature> collectAllFeatures()
+		private List<Ocsm.Dnd.Fifth.Feature> collectAllFeatures()
 		{
-			var allFeatures = new List<OCSM.DnD.Fifth.Feature>();
+			var allFeatures = new List<Ocsm.Dnd.Fifth.Feature>();
 			if(SheetData.Background is Background background && background.Features.Count > 0)
 				allFeatures.AddRange(background.Features);
 			if(SheetData.Race is Race race && race.Features.Count > 0)
@@ -383,7 +383,7 @@ namespace OCSM.Nodes.DnD.Sheets
 			foreach(Node child in raceFeatures.GetChildren())
 				child.QueueFree();
 			
-			var resource = GD.Load<PackedScene>(Constants.Scene.DnD.Fifth.Feature);
+			var resource = GD.Load<PackedScene>(Constants.Scene.Dnd.Fifth.Feature);
 			if(SheetData.Background is Background background && background.Features.Any())
 				background.Features.ForEach(f => renderFeature(backgroundFeatures, f, resource, f.Equals(background.Features.Last())));
 			if(SheetData.Race is Race race && race.Features.Any())
@@ -392,9 +392,9 @@ namespace OCSM.Nodes.DnD.Sheets
 			updateCalculatedTraits();
 		}
 		
-		private void renderFeature(Container node, OCSM.DnD.Fifth.Feature feature, PackedScene resource, bool separator = false)
+		private void renderFeature(Container node, Ocsm.Dnd.Fifth.Feature feature, PackedScene resource, bool separator = false)
 		{
-			var instance = resource.Instantiate<OCSM.Nodes.DnD.Fifth.Feature>();
+			var instance = resource.Instantiate<Ocsm.Nodes.Dnd.Fifth.Feature>();
 			node.AddChild(instance);
 			instance.update(feature);
 			

--- a/OCSM/scripts/nodes/meta/BaseAddEditMetadata.cs
+++ b/OCSM/scripts/nodes/meta/BaseAddEditMetadata.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace OCSM.Nodes.Meta
+namespace Ocsm.Nodes.Meta
 {
 	public abstract partial class BaseAddEditMetadata : Window
 	{

--- a/OCSM/scripts/nodes/meta/BasicMetadataEntry.cs
+++ b/OCSM/scripts/nodes/meta/BasicMetadataEntry.cs
@@ -1,9 +1,9 @@
 using Godot;
 using System;
-using OCSM.Meta;
-using OCSM.Nodes.Autoload;
+using Ocsm.Meta;
+using Ocsm.Nodes.Autoload;
 
-namespace OCSM.Nodes.Meta
+namespace Ocsm.Nodes.Meta
 {
 	public partial class BasicMetadataEntry : Container, ICanDelete
 	{

--- a/OCSM/scripts/nodes/meta/ConfirmDeleteEntry.cs
+++ b/OCSM/scripts/nodes/meta/ConfirmDeleteEntry.cs
@@ -1,7 +1,7 @@
 using Godot;
 using System;
 
-namespace OCSM.Nodes.Meta
+namespace Ocsm.Nodes.Meta
 {
 	public partial class ConfirmDeleteEntry : ConfirmationDialog
 	{

--- a/OCSM/scripts/nodes/sheets/CharacterSheet.cs
+++ b/OCSM/scripts/nodes/sheets/CharacterSheet.cs
@@ -2,7 +2,7 @@ using Godot;
 using System.Collections.Generic;
 using System.Text.Json;
 
-namespace OCSM.Nodes.Sheets
+namespace Ocsm.Nodes.Sheets
 {
 	public interface ICharacterSheet
 	{

--- a/OCSM/scripts/util/Attributes.cs
+++ b/OCSM/scripts/util/Attributes.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace OCSM
+namespace Ocsm
 {
 	[AttributeUsage(AttributeTargets.Field)]
 	public class LabelAttribute : Attribute

--- a/OCSM/scripts/util/Constants.cs
+++ b/OCSM/scripts/util/Constants.cs
@@ -1,9 +1,9 @@
 
-namespace OCSM
+namespace Ocsm
 {
 	/// <summary>
 	/// Class containing all constant values which need to be universally
-	/// accessible within OCSM.
+	/// accessible within Ocsm.
 	/// </summary>
 	public class Constants
 	{
@@ -24,13 +24,13 @@ namespace OCSM
 		
 		public sealed class GameSystem
 		{
-			public sealed class CoD
+			public sealed class Cofd
 			{
 				public const string Mortal = "CodMortal";
 				public const string Changeling = "CodChangeling";
 			}
 			
-			public sealed class DnD
+			public sealed class Dnd
 			{
 				public const string Fifth = "Dnd5e";
 			}
@@ -43,8 +43,8 @@ namespace OCSM
 			
 			public sealed class DataType
 			{
-				public const string CodMortal = "OCSM.Mortal";
-				public const string CodChangeling = "OCSM.Changeling";
+				public const string CodMortal = "Ocsm.Mortal";
+				public const string CodChangeling = "Ocsm.Changeling";
 			}
 		}
 		
@@ -61,7 +61,7 @@ namespace OCSM
 		public sealed class Scene
 		{
 			public const string AboutGodot = "res://scenes/AboutGodot.tscn";
-			public const string AboutOCSM = "res://scenes/AboutOCSM.tscn";
+			public const string AboutOcsm = "res://scenes/AboutOcsm.tscn";
 			public const string ConfirmQuit = "res://scenes/ConfirmQuit.tscn";
 			public const string DarkPack = "res://scenes/DarkPack.tscn";
 			public const string GameSystemLicenses = "res://scenes/GameSystemLicenses.tscn";
@@ -76,7 +76,7 @@ namespace OCSM
 				public const string ConfirmDeleteEntry = "res://scenes/meta/ConfirmDeleteEntry.tscn";
 			}
 			
-			public sealed class CoD
+			public sealed class Cofd
 			{
 				public const string ItemDots = "res://scenes/cod/nodes/ItemDots.tscn";
 				public const string Specialty = "res://scenes/cod/nodes/Specialty.tscn";
@@ -101,23 +101,23 @@ namespace OCSM
 				}
 			}
 			
-			public sealed class DnD
+			public sealed class Dnd
 			{
 				public sealed class Fifth
 				{
-					public const string Skill = "res://scenes/dnd/fifth/Skill.tscn";
-					public const string Sheet = "res://scenes/dnd/sheets/Fifth.tscn";
+					public const string Skill = "res://scenes/Dnd/Fifth/Skill.tscn";
+					public const string Sheet = "res://scenes/Dnd/sheets/Fifth.tscn";
 					public const string NewSheetName = "New Adventurer";
-					public const string Feature = "res://scenes/dnd/fifth/Feature.tscn";
-					public const string FeatureSection = "res://scenes/dnd/fifth/FeatureSection.tscn";
-					public const string InventoryItem = "res://scenes/dnd/fifth/InventoryItem.tscn";
+					public const string Feature = "res://scenes/Dnd/Fifth/Feature.tscn";
+					public const string FeatureSection = "res://scenes/Dnd/Fifth/FeatureSection.tscn";
+					public const string InventoryItem = "res://scenes/Dnd/Fifth/InventoryItem.tscn";
 					
 					public sealed class Meta
 					{
-						public const string AddEditMetadata = "res://scenes/dnd/fifth/meta/DndFifthAddEditMetadata.tscn";
-						public const string FeatureSectionEntry = "res://scenes/dnd/fifth/meta/FeatureSectionEntry.tscn";
-						public const string FeatureEntry = "res://scenes/dnd/fifth/meta/FeatureEntry.tscn";
-						public const string NumericBonusEdit = "res://scenes/dnd/fifth/meta/NumericBonusEdit.tscn";
+						public const string AddEditMetadata = "res://scenes/Dnd/Fifth/meta/DndFifthAddEditMetadata.tscn";
+						public const string FeatureSectionEntry = "res://scenes/Dnd/Fifth/meta/FeatureSectionEntry.tscn";
+						public const string FeatureEntry = "res://scenes/Dnd/Fifth/meta/FeatureEntry.tscn";
+						public const string NumericBonusEdit = "res://scenes/Dnd/Fifth/meta/NumericBonusEdit.tscn";
 					}
 				}
 			}

--- a/OCSM/scripts/util/Enums.cs
+++ b/OCSM/scripts/util/Enums.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 
-namespace OCSM
+namespace Ocsm
 {
 	/// <summary>
 	/// Class providing convenience methods for evaluating logic.

--- a/OCSM/scripts/util/Extensions.cs
+++ b/OCSM/scripts/util/Extensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Godot;
 
-namespace OCSM
+namespace Ocsm
 {
 	public static class Extensions
 	{

--- a/OCSM/scripts/util/FileSystemUtilities.cs
+++ b/OCSM/scripts/util/FileSystemUtilities.cs
@@ -1,14 +1,14 @@
 using System;
 using System.IO;
 
-namespace OCSM
+namespace Ocsm
 {
 	/// <summary>
 	/// Class providing convenience methods for interacting with the file system in an OS-agnostic fashion.
 	/// </summary>
 	public class FileSystemUtilities
 	{
-		private const string App = "/OCSM/";
+		private const string App = "/Ocsm/";
 		private const string Sheets = App + "sheets/";
 		private const string Metadata = App + "metadata/";
 		

--- a/OCSM/scripts/util/Logic.cs
+++ b/OCSM/scripts/util/Logic.cs
@@ -1,5 +1,5 @@
 
-namespace OCSM
+namespace Ocsm
 {
 	/// <summary>
 	/// Class providing convenience methods for evaluating logic.

--- a/OCSM/scripts/util/NodeUtilities.cs
+++ b/OCSM/scripts/util/NodeUtilities.cs
@@ -1,9 +1,9 @@
 using Godot;
 using System.Collections.Generic;
-using OCSM.Nodes;
-using OCSM.Nodes.Meta;
+using Ocsm.Nodes;
+using Ocsm.Nodes.Meta;
 
-namespace OCSM
+namespace Ocsm
 {
 	/// <summary>
 	/// A collection of utility methods for creating or modifying one or more
@@ -23,7 +23,7 @@ namespace OCSM
 		}
 		
 		/// <summary>
-		/// Instantiate and display the <c>OCSM.Nodes.Meta.ConfirmDeleteEntry</c> node.
+		/// Instantiate and display the <c>Ocsm.Nodes.Meta.ConfirmDeleteEntry</c> node.
 		/// </summary>
 		/// <param name="label">The text denoting what is being deleted.</param>
 		/// <param name="parent">The <c>Godot.Node</c> to which to add the instance.</param>

--- a/OCSM/scripts/util/Transport.cs
+++ b/OCSM/scripts/util/Transport.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace OCSM
+namespace Ocsm
 {
 	/// <summary>
 	/// Generic container for transferring an object which does not extend

--- a/OCSM/scripts/util/cod/TraitAttribute.cs
+++ b/OCSM/scripts/util/cod/TraitAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Reflection;
 
-namespace OCSM.CoD
+namespace Ocsm.Cofd
 {
 	[AttributeUsage(AttributeTargets.Field)]
 	public class TraitAttribute : System.Attribute


### PR DESCRIPTION
Rearranges the Ability Score layout of Dnd5e sheet into a vertical orientation. This allows the the ability scores and modifiers to be in one column, with the saving throws and skills in another column, all while still being clearly associated with their relevant abilities.

Closes #11,